### PR TITLE
Change "setup" to "set up"

### DIFF
--- a/docs/caching/quickstart-caching.md
+++ b/docs/caching/quickstart-caching.md
@@ -12,7 +12,7 @@ Cloud-native apps often require various types of scalable caching solutions to i
 
 > [!div class="checklist"]
 >
-> - Create a basic ASP.NET core app that is setup to use .NET Aspire.
+> - Create a basic ASP.NET core app that is set up to use .NET Aspire.
 > - Add .NET Aspire components to connect to Redis and implement caching.
 > - Configure the .NET Aspire components to meet specific requirements.
 

--- a/docs/components-overview.md
+++ b/docs/components-overview.md
@@ -86,7 +86,7 @@ After four steps, you now have a fully configured PostgreSQL database component 
 
 ## Configure .NET Aspire components
 
-.NET Aspire components implement a consistent configuration experiences via <xref:Microsoft.Extensions.Configuration.IConfiguration> and <xref:Microsoft.Extensions.Options.IOptions%601>. Configuration is schematized and part of a component's contract, ensuring backward compatibility across versions of the component. You can setup every .NET Aspire component through either JSON configuration files or directly through code using delegates. JSON files must follow a standardized naming convention based on the Component name.
+.NET Aspire components implement a consistent configuration experiences via <xref:Microsoft.Extensions.Configuration.IConfiguration> and <xref:Microsoft.Extensions.Options.IOptions%601>. Configuration is schematized and part of a component's contract, ensuring backward compatibility across versions of the component. You can set up every .NET Aspire component through either JSON configuration files or directly through code using delegates. JSON files must follow a standardized naming convention based on the Component name.
 
 For example, add the following code to the _appsettings.json_ file to configure the PostgreSQL component:
 

--- a/docs/database/postgresql-entity-framework-component.md
+++ b/docs/database/postgresql-entity-framework-component.md
@@ -66,7 +66,7 @@ The .NET Aspire PostgreSQL Entity Framework Core component provides multiple con
 
 ### Use configuration providers
 
-The .NET Aspire PostgreSQL Entity Framework Core component supports <xref:Microsoft.Extensions.Configuration?displayProperty=fullName>. It loads the `NpgsqlEntityFrameworkCorePostgreSQLSettings` from configuration files such as _appsettings.json_ by using the `Aspire:Npgsql:EntityFrameworkCore:PostgreSQL` key. If you have setup your configurations in the `Aspire:Npgsql:EntityFrameworkCore:PostgreSQL` section you can just call the method without passing any parameter.
+The .NET Aspire PostgreSQL Entity Framework Core component supports <xref:Microsoft.Extensions.Configuration?displayProperty=fullName>. It loads the `NpgsqlEntityFrameworkCorePostgreSQLSettings` from configuration files such as _appsettings.json_ by using the `Aspire:Npgsql:EntityFrameworkCore:PostgreSQL` key. If you have set up your configurations in the `Aspire:Npgsql:EntityFrameworkCore:PostgreSQL` section you can just call the method without passing any parameter.
 
 The following example shows an _appsettings.json_ file that configures some of the available options:
 

--- a/docs/database/sql-server-entity-framework-component.md
+++ b/docs/database/sql-server-entity-framework-component.md
@@ -62,7 +62,7 @@ The .NET Aspire SQL Server Entity Framework Core component provides multiple con
 
 ### Use configuration providers
 
-The .NET Aspire SQL Server Entity Framework Core component supports <xref:Microsoft.Extensions.Configuration?displayProperty=fullName>. It loads the `MicrosoftEntityFrameworkCoreSqlServerSettings` from configuration files such as _appsettings.json_ by using the `Aspire:SqlServer:EntityFrameworkCore:SqlClient` key. If you have setup your configurations in the `Aspire:SqlServer:EntityFrameworkCore:SqlClient` section you can just call the method without passing any parameter.
+The .NET Aspire SQL Server Entity Framework Core component supports <xref:Microsoft.Extensions.Configuration?displayProperty=fullName>. It loads the `MicrosoftEntityFrameworkCoreSqlServerSettings` from configuration files such as _appsettings.json_ by using the `Aspire:SqlServer:EntityFrameworkCore:SqlClient` key. If you have set up your configurations in the `Aspire:SqlServer:EntityFrameworkCore:SqlClient` section you can just call the method without passing any parameter.
 
 The following is an example of an _appsettings.json_ file that configures some of the available options:
 

--- a/docs/get-started/quickstart-build-your-first-aspire-app.md
+++ b/docs/get-started/quickstart-build-your-first-aspire-app.md
@@ -14,7 +14,7 @@ In this quickstart, you explore the following tasks:
 
 > [!div class="checklist"]
 >
-> - Create a basic .NET app that is setup to use .NET Aspire.
+> - Create a basic .NET app that is set up to use .NET Aspire.
 > - Add and configure a .NET Aspire component to implement caching.
 > - Create an API and use service discovery to connect to it.
 > - Orchestrate communication between a front end UI, a back end API, and a local Redis cache.

--- a/docs/includes/aspire-create-sample-generic.md
+++ b/docs/includes/aspire-create-sample-generic.md
@@ -1,6 +1,6 @@
 ## Create the sample solution
 
-Visual Studio provides app templates to get started with Aspire that handle some of the initial setup configurations for you. Complete the following steps to properly setup a project for this quickstart:
+Visual Studio provides app templates to get started with Aspire that handle some of the initial setup configurations for you. Complete the following steps to properly set up a project for this quickstart:
 
 1. At the top of Visual Studio, navigate to **File** > **New** > **Project**.
 1. In the dialog window, search for *ASP.NET Core* and select **ASP.NET Core Web App**. Choose **Next**.

--- a/docs/messaging/azure-service-bus-component.md
+++ b/docs/messaging/azure-service-bus-component.md
@@ -74,7 +74,7 @@ The Service Bus component supports <xref:Microsoft.Extensions.Configuration?disp
 }
 ```
 
-If you have setup your configurations in the `Aspire.Azure.Messaging.ServiceBus` section of your _appsettings.json_ file you can just call the method `AddAzureServiceBus` without passing any parameters.
+If you have set up your configurations in the `Aspire.Azure.Messaging.ServiceBus` section of your _appsettings.json_ file you can just call the method `AddAzureServiceBus` without passing any parameters.
 
 ### Use inline delegates
 
@@ -85,7 +85,7 @@ builder.AddAzureServiceBus(
     static settings => settings.Namespace = "YOUR_SERVICE_BUS_NAMESPACE");
 ```
 
-You can also setup the [ServiceBusClientOptions](/dotnet/api/azure.messaging.servicebus.servicebusclientoptions) using `Action<IAzureClientBuilder<ServiceBusClient, ServiceBusClientOptions>>` delegate, the second parameter of the `AddAzureServiceBus` method. For example to set the `ServiceBusClient` ID to identify the client:
+You can also set up the [ServiceBusClientOptions](/dotnet/api/azure.messaging.servicebus.servicebusclientoptions) using `Action<IAzureClientBuilder<ServiceBusClient, ServiceBusClientOptions>>` delegate, the second parameter of the `AddAzureServiceBus` method. For example to set the `ServiceBusClient` ID to identify the client:
 
 ```csharp
 builder.AddAzureServiceBus(

--- a/docs/messaging/quickstart-messaging.md
+++ b/docs/messaging/quickstart-messaging.md
@@ -12,7 +12,7 @@ Cloud-native apps often require scalable messaging solutions that provide capabi
 
 > [!div class="checklist"]
 >
-> - Create a basic .NET app that is setup to use .NET Aspire Components
+> - Create a basic .NET app that is set up to use .NET Aspire Components
 > - Add an .NET Aspire component to connect to Azure Service Bus
 > - Configure and use .NET Aspire component features to send and receive data
 
@@ -20,13 +20,13 @@ Cloud-native apps often require scalable messaging solutions that provide capabi
 
 ## Set up the Azure Service Bus account
 
-For this quickstart, you'll need access to an Azure Service Bus namespace with a topic and subscription configured. Use one of the following options to setup the require resources:
+For this quickstart, you'll need access to an Azure Service Bus namespace with a topic and subscription configured. Use one of the following options to set up the require resources:
 
 - **Azure portal**: [Create a service bus account with a topic and subscription](/azure/service-bus-messaging/service-bus-quickstart-topics-subscriptions-portal).
 
 Alternatively:
 
-- **Azure CLI**: Run the following commands in the Azure CLI or CloudShell to setup the required Azure Service Bus resources:
+- **Azure CLI**: Run the following commands in the Azure CLI or CloudShell to set up the required Azure Service Bus resources:
 
     ```azurecli-interactive
     az group create -n <your-resource-group-name> -location eastus
@@ -61,7 +61,7 @@ Retrieve the connection string for your Service Bus namespace from the **Shared 
 
 ## Create the sample solution
 
-Visual Studio provides app templates to get started with .NET Aspire that handle some of the initial setup configurations for you. Complete the following steps to properly setup a project for this quickstart:
+Visual Studio provides app templates to get started with .NET Aspire that handle some of the initial setup configurations for you. Complete the following steps to properly set up a project for this quickstart:
 
 1. At the top of Visual Studio, navigate to **File** > **New** > **Project**.
 1. In the dialog window, search for *ASP.NET Core* and select **ASP.NET Core Web API**. Choose **Next**.

--- a/docs/messaging/rabbitmq-client-component.md
+++ b/docs/messaging/rabbitmq-client-component.md
@@ -97,7 +97,7 @@ builder.AddRabbitMQ(
     static settings => settings.HealthChecks = false);
 ```
 
-You can also setup the [IConnectionFactory](https://rabbitmq.github.io/rabbitmq-dotnet-client/api/RabbitMQ.Client.IConnectionFactory.html) using the `Action<IConnectionFactory> configureConnectionFactory` delegate parameter of the `AddRabbitMQ` method. For example to set the client provided name for connections:
+You can also set up the [IConnectionFactory](https://rabbitmq.github.io/rabbitmq-dotnet-client/api/RabbitMQ.Client.IConnectionFactory.html) using the `Action<IConnectionFactory> configureConnectionFactory` delegate parameter of the `AddRabbitMQ` method. For example to set the client provided name for connections:
 
 ```csharp
 builder.AddRabbitMQ(

--- a/docs/security/azure-security-key-vault-component.md
+++ b/docs/security/azure-security-key-vault-component.md
@@ -74,7 +74,7 @@ The .NET Aspire Azure Key Vault component supports <xref:Microsoft.Extensions.Co
 }
 ```
 
-If you have setup your configurations in the `Aspire:Azure:Security:KeyVault` section of your _appsettings.json_ file you can just call the method `AddAzureKeyVaultSecrets` without passing any parameters.
+If you have set up your configurations in the `Aspire:Azure:Security:KeyVault` section of your _appsettings.json_ file you can just call the method `AddAzureKeyVaultSecrets` without passing any parameters.
 
 ### Use inline delegates
 
@@ -85,7 +85,7 @@ builder.AddAzureKeyVaultSecrets(
     static settings => settings.ServiceUri = new Uri("YOUR_SERVICEURI"));
 ```
 
-You can also setup the <xref:Azure.Security.KeyVault.Secrets.SecretClientOptions> using `Action<IAzureClientBuilder<SecretClient, SecretClientOptions>>` delegate, the second parameter of the `AddAzureKeyVaultSecrets` method. For example to set the <xref:Azure.Security.KeyVault.Keys.KeyClientOptions.DisableChallengeResourceVerification?displayProperty=nameWithType> ID to identify the client:
+You can also set up the <xref:Azure.Security.KeyVault.Secrets.SecretClientOptions> using `Action<IAzureClientBuilder<SecretClient, SecretClientOptions>>` delegate, the second parameter of the `AddAzureKeyVaultSecrets` method. For example to set the <xref:Azure.Security.KeyVault.Keys.KeyClientOptions.DisableChallengeResourceVerification?displayProperty=nameWithType> ID to identify the client:
 
 ```csharp
 builder.AddAzureKeyVaultSecrets(

--- a/docs/storage/azure-storage-blobs-component.md
+++ b/docs/storage/azure-storage-blobs-component.md
@@ -119,7 +119,7 @@ builder.AddAzureBlobService(
     settings => settings.HealthChecks = false);
 ```
 
-You can also setup the `BlobClientOptions` using `Action<IAzureClientBuilder<BlobServiceClient, BlobClientOptions>> configureClientBuilder` delegate, the second parameter of the `AddAzureBlobService` method. For example, to set the first part of user-agent headers for all requests issues by this client:
+You can also set up the `BlobClientOptions` using `Action<IAzureClientBuilder<BlobServiceClient, BlobClientOptions>> configureClientBuilder` delegate, the second parameter of the `AddAzureBlobService` method. For example, to set the first part of user-agent headers for all requests issues by this client:
 
 ```csharp
 builder.AddAzureBlobService(

--- a/docs/storage/azure-storage-queues-component.md
+++ b/docs/storage/azure-storage-queues-component.md
@@ -119,7 +119,7 @@ builder.AddAzureQueueService(
     settings => settings.HealthChecks = false);
 ```
 
-You can also setup the `QueueClientOptions` using `Action<IAzureClientBuilder<QueueServiceClient, QueueClientOptions>> configureClientBuilder` delegate, the second parameter of the `AddAzureQueueService` method. For example, to set the first part of user-agent headers for all requests issues by this client:
+You can also set up the `QueueClientOptions` using `Action<IAzureClientBuilder<QueueServiceClient, QueueClientOptions>> configureClientBuilder` delegate, the second parameter of the `AddAzureQueueService` method. For example, to set the first part of user-agent headers for all requests issues by this client:
 
 ```csharp
 builder.AddAzureQueueService(

--- a/docs/storage/azure-storage-tables-component.md
+++ b/docs/storage/azure-storage-tables-component.md
@@ -81,7 +81,7 @@ The .NET Aspire Azure Table Storage component supports <xref:Microsoft.Extension
 }
 ```
 
-If you have setup your configurations in the `Aspire:Azure:Data:Tables` section of your _appsettings.json_ file you can just call the method `AddAzureTableService` without passing any parameters.
+If you have set up your configurations in the `Aspire:Azure:Data:Tables` section of your _appsettings.json_ file you can just call the method `AddAzureTableService` without passing any parameters.
 
 ### Use inline delegates
 
@@ -92,7 +92,7 @@ builder.AddAzureTableService(
     static settings => settings.ServiceUri = new Uri("YOUR_SERVICEURI"));
 ```
 
-You can also setup the `TableClientOptions` using `Action<IAzureClientBuilder<TableServiceClient, TableClientOptions>>` delegate, the second parameter of the `AddAzureTableService` method. For example to set the `TableServiceClient` ID to identify the client:
+You can also set up the `TableClientOptions` using `Action<IAzureClientBuilder<TableServiceClient, TableClientOptions>>` delegate, the second parameter of the `AddAzureTableService` method. For example to set the `TableServiceClient` ID to identify the client:
 
 ```csharp
 builder.AddAzureTableService(

--- a/docs/storage/quickstart-azure-storage.md
+++ b/docs/storage/quickstart-azure-storage.md
@@ -12,7 +12,7 @@ Cloud-native apps often require scalable storage solutions that provide capabili
 
 > [!div class="checklist"]
 >
-> - Create a basic .NET app that is setup to use .NET Aspire Components
+> - Create a basic .NET app that is set up to use .NET Aspire Components
 > - Add .NET Aspire Components to connect to multiple storage services
 > - Configure and use .NET Aspire Component features to send and receive data
 
@@ -30,7 +30,7 @@ For this quickstart, you'll need data contributor access to an Azure Storage Acc
 
 # [Azure CLI script](#tab/cli)
 
-Run the following commands in the Azure CLI or CloudShell to setup the required Azure Storage resources:
+Run the following commands in the Azure CLI or CloudShell to set up the required Azure Storage resources:
 
 ```azurecli-interactive
 az group create --name aspirestorage --location eastus2


### PR DESCRIPTION
...when it's used as a verb (we were already doing this in many places).  Leave it as "setup" when it's used as a noun.