### PR TITLE
Update postgresql-entity-framework-component.md: Replace Azure Cosmos DB with PostgreSQL

### DIFF
--- a/docs/database/postgresql-entity-framework-component.md
+++ b/docs/database/postgresql-entity-framework-component.md
@@ -7,7 +7,7 @@ ms.date: 11/15/2023
 
 # .NET Aspire PostgreSQL Entity Framework Core component
 
-In this article, you learn how to use the .NET Aspire PostgreSQL Entity Framework Core component. The `Aspire.Npgsql.EntityFrameworkCore.PostgreSQL` library is used to register a <xref:Microsoft.EntityFrameworkCore.DbContext> as a singleton in the DI container for connecting to Azure Cosmos DB. It also enables corresponding health checks, logging and telemetry.
+In this article, you learn how to use the .NET Aspire PostgreSQL Entity Framework Core component. The `Aspire.Npgsql.EntityFrameworkCore.PostgreSQL` library is used to register a <xref:Microsoft.EntityFrameworkCore.DbContext> service for connecting to a PostgreSQL database. It also enables corresponding health checks, logging and telemetry.
 
 PostgreSQL is a powerful, open source, object-relational database system. The .NET Aspire PostgreSQL Entity Framework component streamlines essential database context and connection configurations for you by handling the following concerns:
 


### PR DESCRIPTION
Replace Azure Cosmos DB with PostgreSQL

## Summary

Replaced Azure Cosmos DB with PostgreSQL



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/database/postgresql-entity-framework-component.md](https://github.com/dotnet/docs-aspire/blob/6a9a32f662955c11eeff3faa20f05069c2b4d9b3/docs/database/postgresql-entity-framework-component.md) | [.NET Aspire PostgreSQL Entity Framework Core component](https://review.learn.microsoft.com/en-us/dotnet/aspire/database/postgresql-entity-framework-component?branch=pr-en-us-59) |

<!-- PREVIEW-TABLE-END -->