### PR TITLE
Update sql-server-entity-framework-component.md

### DIFF
--- a/docs/database/sql-server-entity-framework-component.md
+++ b/docs/database/sql-server-entity-framework-component.md
@@ -69,9 +69,9 @@ The following is an example of an _appsettings.json_ file that configures some o
 ```json
 {
   "Aspire": {
-    "SqlServer": {
+    "Microsoft": {
       "EntityFrameworkCore": {
-        "SqlClient": {
+        "SqlServer": {
           "ConnectionString": "YOUR_CONNECTIONSTRING",
           "DbContextPooling": true,
           "HealthChecks": false,
@@ -102,14 +102,14 @@ If you want to register more than one `DbContext` with different configuration, 
 ```json
 {
   "Aspire": {
-    "SqlServer": {
+    "Microsoft": {
       "EntityFrameworkCore": {
-        "SqlClient": {
-          "ConnectionString": "YOUR_CONNECTIONSTRING",
-          "DbContextPooling": true,
-          "HealthChecks": false,
-          "Tracing": false,
-          "Metrics": true,
+          "SqlServer": {
+            "ConnectionString": "YOUR_CONNECTIONSTRING",
+            "DbContextPooling": true,
+            "HealthChecks": false,
+            "Tracing": false,
+            "Metrics": true,
           "AnotherDbContext": {
             "ConnectionString": "AnotherDbContext_CONNECTIONSTRING",
             "Tracing": true


### PR DESCRIPTION
## Summary
I think the appsettings example is incorrect.
Docs use Aspire:SqlServer:EntityFrameworkCore:SqlClient to configure component but I think it should be Aspire:Microsoft:EntityFrameworkCore:SqlServer as seen in const string DefaultConfigSectionName from AspireSqlServerEFCoreSqlClientExtensions class.



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/database/sql-server-entity-framework-component.md](https://github.com/dotnet/docs-aspire/blob/1087ecb7cf251cb1346a0919082d03e19de6e239/docs/database/sql-server-entity-framework-component.md) | [.NET Aspire SqlServer Entity Framework Core component](https://review.learn.microsoft.com/en-us/dotnet/aspire/database/sql-server-entity-framework-component?branch=pr-en-us-60) |

<!-- PREVIEW-TABLE-END -->