### PR TITLE
removed `targetScope='subscription'` in aca-deployment-bicep.md

### DIFF
--- a/docs/deployment/azure/includes/aca-deployment-bicep.md
+++ b/docs/deployment/azure/includes/aca-deployment-bicep.md
@@ -13,8 +13,6 @@ Now, you'll create two new files - `infra\provision.bicep` and `infra\provision.
 1. In `infra/provision.bicep`, add the following code to the top of the empty file. These lines of code represent the parameters you'll feed the Bicep file using the environment variables you set earlier. The `env` variable is an array that will be passed to both of the container apps hosting your Aspire project code, setting some conventional environment variables useful during development.
 
     ```bicep
-    targetScope = 'subscription'
-
     @minLength(1)
     @maxLength(64)
     @description('Name of the resource group that will contain all the resources')


### PR DESCRIPTION
Since the example uses `az group create --location westus --name aspiretoacarg` to create the subscription-level resource group, the bicep files don't need the `targetScope` to be set to `'subscription'`. Fixes #74

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
