### PR TITLE
Fix typo on Table Storage Component

### DIFF
--- a/docs/storage/azure-storage-queues-component.md
+++ b/docs/storage/azure-storage-queues-component.md
@@ -134,11 +134,11 @@ builder.AddAzureQueueService(
 In your orchestrator project, add a Storage Queue connection and consume the connection using the following methods, such as <xref:Aspire.Hosting.AzureResourceExtensions.AddAzureStorage%2A>:
 
 ```csharp
-var queue = builder.AddAzureStorage("storage")
-    .AddQueues("queue");
+var queues = builder.AddAzureStorage("storage")
+    .AddQueues("queues");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>()
-    .WithReference(queue);
+    .WithReference(queues);
 ```
 
 The <xref:Aspire.Hosting.AzureResourceExtensions.AddQueues%2A> method will read connection information from the AppHost's configuration (for example, from "user secrets") under the `ConnectionStrings:queue` config key. The <xref:Aspire.Hosting.ResourceBuilderExtensions.WithReference%2A> method passes that connection information into a connection string named queue in the `ExampleProject` project. In the _Program.cs_ file of `ExampleProject`, the connection can be consumed using:

--- a/docs/storage/azure-storage-tables-component.md
+++ b/docs/storage/azure-storage-tables-component.md
@@ -151,11 +151,12 @@ In your orchestrator project, register the Azure Table Storage component and con
 
 ```csharp
 // Service registration 
-var tableStorage = builder.AddAzureTableService("tables");
+var tables = builder.AddAzureStorage("storage")
+    .AddTables("tables");
 
 // Service consumption 
 Builder.AddProject<MyApp.ExampleProject>() 
-    .WithReference(tableStorage)
+    .WithReference(tables)
 ```
 
 For more information, see <xref:Aspire.Hosting.ResourceBuilderExtensions.WithReference%2A>.


### PR DESCRIPTION
This PR is to:

- Improve consistency on variables among blobs, queues and tables

```csharp
// blobs
var blobs = builder.AddAzureStorage("storage")
    .AddBlobs("blobs");

// queues
var queues = builder.AddAzureStorage("storage")
    .AddQueues("queues");

// tables
var tables = builder.AddAzureStorage("storage")
    .AddTables("tables");
```

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/storage/azure-storage-queues-component.md](https://github.com/dotnet/docs-aspire/blob/88576d109fe318d4f716de99839ae59cb7a208a5/docs/storage/azure-storage-queues-component.md) | [.NET Aspire Azure Queue Storage component](https://review.learn.microsoft.com/en-us/dotnet/aspire/storage/azure-storage-queues-component?branch=pr-en-us-85) |
| [docs/storage/azure-storage-tables-component.md](https://github.com/dotnet/docs-aspire/blob/88576d109fe318d4f716de99839ae59cb7a208a5/docs/storage/azure-storage-tables-component.md) | [.NET Aspire Azure Data Tables component](https://review.learn.microsoft.com/en-us/dotnet/aspire/storage/azure-storage-tables-component?branch=pr-en-us-85) |

<!-- PREVIEW-TABLE-END -->