### PR TITLE
Fixed typo identified in #89

### DIFF
--- a/docs/get-started/quickstart-build-your-first-aspire-app.md
+++ b/docs/get-started/quickstart-build-your-first-aspire-app.md
@@ -69,7 +69,7 @@ The service defaults project exposes an extension method on the <xref:Microsoft.
 
 ## Orchestrate service communication
 
-.NET Aspire provides orchestration features to assist with configuring connections and communication between the different parts of your app. The _AspireSample.AppHost_ project added the _AspireSample.ApiService_ and _AspireSample.Web_ projects to the application model. It also declared their names as `"webfrontend"` for Blazor front end, `"apiservice"` for the API project reference. Additionally, a Redis container resource labelled `"redis"` was added. These names are used to configure service discovery and communication between the projects in your app.
+.NET Aspire provides orchestration features to assist with configuring connections and communication between the different parts of your app. The _AspireSample.AppHost_ project added the _AspireSample.ApiService_ and _AspireSample.Web_ projects to the application model. It also declared their names as `"webfrontend"` for Blazor front end, `"apiservice"` for the API project reference. Additionally, a Redis container resource labelled `"cache"` was added. These names are used to configure service discovery and communication between the projects in your app.
 
 The front end app defines a typed <xref:System.Net.Http.HttpClient> that's used to communicate with the API project.
 


### PR DESCRIPTION
## Summary

Replaced "redis" with "cache" to match what's added in Program.cs

Fixes #89


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/get-started/quickstart-build-your-first-aspire-app.md](https://github.com/dotnet/docs-aspire/blob/17a671543f22b0932983e715b92c4a0dd2c9bd1e/docs/get-started/quickstart-build-your-first-aspire-app.md) | [Quickstart: Build your first .NET Aspire app](https://review.learn.microsoft.com/en-us/dotnet/aspire/get-started/quickstart-build-your-first-aspire-app?branch=pr-en-us-91) |

<!-- PREVIEW-TABLE-END -->