### PR TITLE
Remove appsettings.json connection strings as the apphost does this

### DIFF
--- a/docs/storage/azure-storage.md
+++ b/docs/storage/azure-storage.md
@@ -142,10 +142,6 @@ When the _AspireStorage_ project starts, it will create a `fileuploads` containe
 
 :::zone-end
 
-In the _appsettings.json_ file of the _AspireStorage_ project, add the corresponding connection information:
-
-:::code language="json" source="snippets/tutorial/AspireStorage/AspireStorage/appsettings.json" highlight="9-12":::
-
 ## Add the .NET Aspire component to the Worker Service
 
 The worker service handles pulling messages off of the Azure Storage queue for processing. Add the [.NET Aspire Azure Queue Storage component](azure-storage-queues-component.md) component package to your _AspireStorage.Worker_ app:
@@ -162,10 +158,6 @@ This method handles the following tasks:
 
 - Register a <xref:Azure.Storage.Queues.QueueServiceClient> with the DI container for connecting to Azure Storage Queues.
 - Automatically enable corresponding health checks, logging, and telemetry for the respective services.
-
-In the _appsettings.json_ file of the _AspireStorage.Worker_ project, add the corresponding connection string information:
-
-:::code language="json" source="snippets/tutorial/AspireStorage/AspireStorage.Worker/appsettings.json" highlight="8-10":::
 
 ## Create the form
 

--- a/docs/storage/snippets/tutorial/AspireStorage/AspireStorage.Worker/appsettings.json
+++ b/docs/storage/snippets/tutorial/AspireStorage/AspireStorage.Worker/appsettings.json
@@ -4,8 +4,5 @@
             "Default": "Information",
             "Microsoft.Hosting.Lifetime": "Information"
         }
-    },
-    "ConnectionStrings": {
-        "QueueConnection": "https://{account_name}.queue.core.windows.net/"
     }
 }

--- a/docs/storage/snippets/tutorial/AspireStorage/AspireStorage/appsettings.json
+++ b/docs/storage/snippets/tutorial/AspireStorage/AspireStorage/appsettings.json
@@ -5,9 +5,5 @@
             "Microsoft.AspNetCore": "Warning"
         }
     },
-    "AllowedHosts": "*",
-    "ConnectionStrings": {
-        "BlobConnection": "https://{account_name}.blob.core.windows.net/",
-        "QueueConnection": "https://{account_name}.queue.core.windows.net/"
-    }
+    "AllowedHosts": "*"
 }


### PR DESCRIPTION
Remove _appsettings.json_ connection strings as the AppHost does this.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/storage/azure-storage.md](https://github.com/dotnet/docs-aspire/blob/5c61373fc738ea4c7cd328902fdd549e0880b736/docs/storage/azure-storage.md) | [Tutorial: Connect an ASP.NET Core app to .NET Aspire storage components](https://review.learn.microsoft.com/en-us/dotnet/aspire/storage/azure-storage?branch=pr-en-us-118) |

<!-- PREVIEW-TABLE-END -->