### PR TITLE
Fix typo in add-aspire-existing-app.md

### DIFF
--- a/docs/get-started/add-aspire-existing-app.md
+++ b/docs/get-started/add-aspire-existing-app.md
@@ -62,7 +62,7 @@ Now, let's enroll the **Store** project, which implements the web user interface
 
     :::image type="content" source="media/add-aspire-orchestrator-support.png" alt-text="Screenshot of the Add .NET Aspire Orchestrator Support dialog.":::
 
-Visual Studio add two new projects to the solution:
+Visual Studio adds two new projects to the solution:
 
 - **eShopLite.AppHost**: An orchestrator project designed to connect and configure the different projects and services of your app. The orchestrator is set as the _Startup project_, and it depends on the **eShopLite.Store** project.
 - **eShopLite.ServiceDefaults**: A .NET Aspire shared project to manage configurations that are reused across the projects in your solution related to [resilience](/dotnet/core/resilience/http-resilience), [service discovery](../service-discovery/overview.md), and [telemetry](../telemetry.md).


### PR DESCRIPTION
The sentence:

> Visual Studio **add** two new...

Should read:

> Visual Studio **adds** two new