### PR TITLE
Fix typos and grammar in k8s deployment documentation

### DIFF
--- a/docs/deployment/k8s-deployment.md
+++ b/docs/deployment/k8s-deployment.md
@@ -13,7 +13,7 @@ ms.date: 12/09/2023
 > - The prerequisites that must be in place for the Aspirate tool.
 > - How .NET Aspire and Kubernetes manifest files differ.
 > - How to install and initialize the Aspirate tool.
-> - How to create and manifests and containers and deploy them to a Kubernetes cluster.
+> - How to create manifests and containers and deploy them to a Kubernetes cluster.
 
 [!INCLUDE [aspire-prereqs](../includes/aspire-prereqs.md)]
 

--- a/docs/deployment/k8s-deployment.md
+++ b/docs/deployment/k8s-deployment.md
@@ -1,7 +1,7 @@
 ---
 title: Deploy .NET Aspire apps to a Kubernetes cluster
 description: Learn how to use the Aspirate tool to deploy .NET Aspire apps to a Kubernetes cluster.
-ms.date: 12/07/2023
+ms.date: 12/09/2023
 ---
 
 # Deploy .NET Aspire apps to a Kubernetes cluster
@@ -10,7 +10,7 @@ ms.date: 12/07/2023
 
 > [!div class="checklist"]
 >
-> - The prerequisites that must be in placed for the Aspirate tool.
+> - The prerequisites that must be in place for the Aspirate tool.
 > - How .NET Aspire and Kubernetes manifest files differ.
 > - How to install and initialize the Aspirate tool.
 > - How to create and manifests and containers and deploy them to a Kubernetes cluster.


### PR DESCRIPTION
## Summary

Fix typos and grammar in k8s deployment documentation

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/deployment/k8s-deployment.md](https://github.com/dotnet/docs-aspire/blob/9ac0c78e956e209055f90293f2a055679e2cba17/docs/deployment/k8s-deployment.md) | [Deploy .NET Aspire apps to a Kubernetes cluster](https://review.learn.microsoft.com/en-us/dotnet/aspire/deployment/k8s-deployment?branch=pr-en-us-152) |

<!-- PREVIEW-TABLE-END -->