### PR TITLE
Remove AddDatabase from Cosmos DB resource.

### DIFF
--- a/docs/database/azure-cosmos-db-component.md
+++ b/docs/database/azure-cosmos-db-component.md
@@ -134,8 +134,7 @@ In your orchestrator project, register the .NET Aspire Azure Cosmos DB component
 
 ```csharp
 // Service registration
-var cosmosdb = builder.AddAzureCosmosDB("cdb")
-    .AddDatabase("cosmosdb");
+var cosmosdb = builder.AddAzureCosmosDB("cdb");
 
 // Service consumption
 var exampleProject = builder.AddProject<Projects.ExampleProject>()


### PR DESCRIPTION
Docs are incorrect. There is no AddDatabase(...) method on the Cosmos resource builder.

## Summary

Removed reference to the extension method.

Fixes #154 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/database/azure-cosmos-db-component.md](https://github.com/dotnet/docs-aspire/blob/7b81dbbd8c829ef623067ed200bc1dfd2506c169/docs/database/azure-cosmos-db-component.md) | [.NET Aspire Azure Cosmos DB component](https://review.learn.microsoft.com/en-us/dotnet/aspire/database/azure-cosmos-db-component?branch=pr-en-us-155) |

<!-- PREVIEW-TABLE-END -->