### PR TITLE
Update sql-server-component.md

### DIFF
--- a/docs/database/sql-server-component.md
+++ b/docs/database/sql-server-component.md
@@ -9,15 +9,15 @@ ms.date: 12/01/2023
 
 In this article, you learn how to use the .NET Aspire SQL Server component. The `Aspire.Microsoft.Data.SqlClient` library:
 
--   Registers a scoped <xref:Microsoft.Data.SqlClient.SqlConnection?displayProperty=fullName> factory in the DI container for connecting Azure SQL, MS SQL database.
--   Automatically configures the following:
-    -   Connection pooling to efficiently managed HTTP requests and database connections
-    -   Automatic retries to increase app resiliency
-    -   Health checks, logging and telemetry to improve app monitoring and diagnostics
+- Registers a scoped <xref:Microsoft.Data.SqlClient.SqlConnection?displayProperty=fullName> factory in the DI container for connecting Azure SQL, MS SQL database.
+- Automatically configures the following:
+  - Connection pooling to efficiently managed HTTP requests and database connections
+  - Automatic retries to increase app resiliency
+  - Health checks, logging and telemetry to improve app monitoring and diagnostics
 
 ## Prerequisites
 
--   An [Azure SQL Database](/azure/azure-sql/database) or [SQL Server](/sql/sql-server) database and the connection string for accessing the database.
+- An [Azure SQL Database](/azure/azure-sql/database) or [SQL Server](/sql/sql-server) database and the connection string for accessing the database.
 
 ## Get started
 
@@ -149,8 +149,8 @@ builder.AddSqlServerClient("sqldata");
 
 By default, the .NET Aspire Sql Server component handles the following:
 
--   Adds the [`SqlServerHealthCheck`](https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/blob/master/src/HealthChecks.NpgSql/NpgSqlHealthCheck.cs), which verifies that a connection can be made commands can be run against the SQL Database.
--   Integrates with the `/health` HTTP endpoint, which specifies all registered health checks must pass for app to be considered ready to accept traffic
+- Adds the [`SqlServerHealthCheck`](https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/blob/master/src/HealthChecks.NpgSql/NpgSqlHealthCheck.cs), which verifies that a connection can be made commands can be run against the SQL Database.
+- Integrates with the `/health` HTTP endpoint, which specifies all registered health checks must pass for app to be considered ready to accept traffic
 
 [!INCLUDE [component-observability-and-telemetry](../includes/component-observability-and-telemetry.md)]
 
@@ -162,33 +162,33 @@ The .NET Aspire SQL Server component currently doesn't enable logging by default
 
 The .NET Aspire SQL Server component will emit the following Tracing activities using OpenTelemetry:
 
--   OpenTelemetry.Instrumentation.SqlClient
+- OpenTelemetry.Instrumentation.SqlClient
 
 ### Metrics
 
 The .NET Aspire SQL Server component will emit the following metrics using OpenTelemetry:
 
--   Microsoft.Data.SqlClient.EventSource
-    -   active-hard-connections
-    -   hard-connects
-    -   hard-disconnects
-    -   active-soft-connects
-    -   soft-connects
-    -   soft-disconnects
-    -   number-of-non-pooled-connections
-    -   number-of-pooled-connections
-    -   number-of-active-connection-pool-groups
-    -   number-of-inactive-connection-pool-groups
-    -   number-of-active-connection-pools
-    -   number-of-inactive-connection-pools
-    -   number-of-active-connections
-    -   number-of-free-connections
-    -   number-of-stasis-connections
-    -   number-of-reclaimed-connections
+- Microsoft.Data.SqlClient.EventSource
+  - active-hard-connections
+  - hard-connects
+  - hard-disconnects
+  - active-soft-connects
+  - soft-connects
+  - soft-disconnects
+  - number-of-non-pooled-connections
+  - number-of-pooled-connections
+  - number-of-active-connection-pool-groups
+  - number-of-inactive-connection-pool-groups
+  - number-of-active-connection-pools
+  - number-of-inactive-connection-pools
+  - number-of-active-connections
+  - number-of-free-connections
+  - number-of-stasis-connections
+  - number-of-reclaimed-connections
 
 ## See also
 
--   [Azure SQL Database](/azure/azure-sql/database)
--   [SQL Server](/sql/sql-server)
--   [.NET Aspire components](../fundamentals/components-overview.md)
--   [.NET Aspire GitHub repo](https://github.com/dotnet/aspire)
+- [Azure SQL Database](/azure/azure-sql/database)
+- [SQL Server](/sql/sql-server)
+- [.NET Aspire components](../fundamentals/components-overview.md)
+- [.NET Aspire GitHub repo](https://github.com/dotnet/aspire)

--- a/docs/database/sql-server-component.md
+++ b/docs/database/sql-server-component.md
@@ -9,15 +9,15 @@ ms.date: 12/01/2023
 
 In this article, you learn how to use the .NET Aspire SQL Server component. The `Aspire.Microsoft.Data.SqlClient` library:
 
-- Registers a scoped <xref:Microsoft.Data.SqlClient.SqlConnection?displayProperty=fullName> factory in the DI container for connecting Azure SQL, MS SQL database.
-- Automatically configures the following:
-  - Connection pooling to efficiently managed HTTP requests and database connections
-  - Automatic retries to increase app resiliency
-  - Health checks, logging and telemetry to improve app monitoring and diagnostics
+-   Registers a scoped <xref:Microsoft.Data.SqlClient.SqlConnection?displayProperty=fullName> factory in the DI container for connecting Azure SQL, MS SQL database.
+-   Automatically configures the following:
+    -   Connection pooling to efficiently managed HTTP requests and database connections
+    -   Automatic retries to increase app resiliency
+    -   Health checks, logging and telemetry to improve app monitoring and diagnostics
 
 ## Prerequisites
 
-- An [Azure SQL Database](/azure/azure-sql/database) or [SQL Server](/sql/sql-server) database and the connection string for accessing the database.
+-   An [Azure SQL Database](/azure/azure-sql/database) or [SQL Server](/sql/sql-server) database and the connection string for accessing the database.
 
 ## Get started
 
@@ -42,10 +42,10 @@ For more information, see [dotnet add package](/dotnet/core/tools/dotnet-add-pac
 
 ## Example usage
 
-In the _Program.cs_ file of your project, call the <xref:Microsoft.Extensions.Hosting.AspireSqlServerSqlClientExtensions.AddSqlServerClient%2A> extension to register a <xref:System.Data.SqlClient.SqlConnection> for use via the dependency injection container.
+In the _Program.cs_ file of your project, call the <xref:Microsoft.Extensions.Hosting.AspireSqlServerSqlClientExtensions.AddSqlServerConnection%2A> extension to register a <xref:System.Data.SqlClient.SqlConnection> for use via the dependency injection container.
 
 ```csharp
-builder.AddSqlServerClient("sql");
+builder.AddSqlServerConnection("sql");
 ```
 
 To retrieve your `SqlConnection` object an example service:
@@ -71,15 +71,15 @@ The following example shows an _appsettings.json_ file that configures some of t
 
 ```json
 {
-  "Aspire": {
-    "SqlServer": {
-      "SqlClient": {
-        "ConnectionString": "YOUR_CONNECTIONSTRING",
-        "HealthChecks": true,
-        "Metrics": false
-      }
+    "Aspire": {
+        "SqlServer": {
+            "SqlClient": {
+                "ConnectionString": "YOUR_CONNECTIONSTRING",
+                "HealthChecks": true,
+                "Metrics": false
+            }
+        }
     }
-  }
 }
 ```
 
@@ -98,16 +98,16 @@ If you want to add more than one `SqlConnection` you could use named instances. 
 
 ```json
 {
-  "Aspire": {
-    "SqlServer": {
-      "SqlClient": {
-        "INSTANCE_NAME": {
-          "ServiceUri": "YOUR_URI",
-          "HealthChecks": false
+    "Aspire": {
+        "SqlServer": {
+            "SqlClient": {
+                "INSTANCE_NAME": {
+                    "ServiceUri": "YOUR_URI",
+                    "HealthChecks": false
+                }
+            }
         }
-      }
     }
-  }
 }
 ```
 
@@ -121,12 +121,12 @@ builder.AddSqlServerSqlClientConfig("INSTANCE_NAME");
 
 Here are the configurable options with corresponding default values:
 
-| Name | Description |
-|--|--|
-| `ConnectionString` | The connection string of the SQL Server database to connect to. |
-| `HealthChecks` | A boolean value that indicates whether the database health check is enabled or not. |
-| `Tracing` | A boolean value that indicates whether the OpenTelemetry tracing is enabled or not. |
-| `Metrics` | A boolean value that indicates whether the OpenTelemetry metrics are enabled or not. |
+| Name               | Description                                                                          |
+| ------------------ | ------------------------------------------------------------------------------------ |
+| `ConnectionString` | The connection string of the SQL Server database to connect to.                      |
+| `HealthChecks`     | A boolean value that indicates whether the database health check is enabled or not.  |
+| `Tracing`          | A boolean value that indicates whether the OpenTelemetry tracing is enabled or not.  |
+| `Metrics`          | A boolean value that indicates whether the OpenTelemetry metrics are enabled or not. |
 
 ## Orchestration
 
@@ -149,8 +149,8 @@ builder.AddSqlServerClient("sqldata");
 
 By default, the .NET Aspire Sql Server component handles the following:
 
-- Adds the [`SqlServerHealthCheck`](https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/blob/master/src/HealthChecks.NpgSql/NpgSqlHealthCheck.cs), which verifies that a connection can be made commands can be run against the SQL Database.
-- Integrates with the `/health` HTTP endpoint, which specifies all registered health checks must pass for app to be considered ready to accept traffic
+-   Adds the [`SqlServerHealthCheck`](https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/blob/master/src/HealthChecks.NpgSql/NpgSqlHealthCheck.cs), which verifies that a connection can be made commands can be run against the SQL Database.
+-   Integrates with the `/health` HTTP endpoint, which specifies all registered health checks must pass for app to be considered ready to accept traffic
 
 [!INCLUDE [component-observability-and-telemetry](../includes/component-observability-and-telemetry.md)]
 
@@ -162,33 +162,33 @@ The .NET Aspire SQL Server component currently doesn't enable logging by default
 
 The .NET Aspire SQL Server component will emit the following Tracing activities using OpenTelemetry:
 
-- OpenTelemetry.Instrumentation.SqlClient
+-   OpenTelemetry.Instrumentation.SqlClient
 
 ### Metrics
 
 The .NET Aspire SQL Server component will emit the following metrics using OpenTelemetry:
 
-- Microsoft.Data.SqlClient.EventSource
-  - active-hard-connections
-  - hard-connects
-  - hard-disconnects
-  - active-soft-connects
-  - soft-connects
-  - soft-disconnects
-  - number-of-non-pooled-connections
-  - number-of-pooled-connections
-  - number-of-active-connection-pool-groups
-  - number-of-inactive-connection-pool-groups
-  - number-of-active-connection-pools
-  - number-of-inactive-connection-pools
-  - number-of-active-connections
-  - number-of-free-connections
-  - number-of-stasis-connections
-  - number-of-reclaimed-connections
+-   Microsoft.Data.SqlClient.EventSource
+    -   active-hard-connections
+    -   hard-connects
+    -   hard-disconnects
+    -   active-soft-connects
+    -   soft-connects
+    -   soft-disconnects
+    -   number-of-non-pooled-connections
+    -   number-of-pooled-connections
+    -   number-of-active-connection-pool-groups
+    -   number-of-inactive-connection-pool-groups
+    -   number-of-active-connection-pools
+    -   number-of-inactive-connection-pools
+    -   number-of-active-connections
+    -   number-of-free-connections
+    -   number-of-stasis-connections
+    -   number-of-reclaimed-connections
 
 ## See also
 
-- [Azure SQL Database](/azure/azure-sql/database)
-- [SQL Server](/sql/sql-server)
-- [.NET Aspire components](../fundamentals/components-overview.md)
-- [.NET Aspire GitHub repo](https://github.com/dotnet/aspire)
+-   [Azure SQL Database](/azure/azure-sql/database)
+-   [SQL Server](/sql/sql-server)
+-   [.NET Aspire components](../fundamentals/components-overview.md)
+-   [.NET Aspire GitHub repo](https://github.com/dotnet/aspire)


### PR DESCRIPTION
## Summary

Update the documentation to use the _AddSqlServerConnection_ extension method instead of the _AddSqlServerClient_ that seems not to exist.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/database/sql-server-component.md](https://github.com/dotnet/docs-aspire/blob/a239992fd96e191d5c53540f54414eed9ac3e09a/docs/database/sql-server-component.md) | [.NET Aspire SQL Server component](https://review.learn.microsoft.com/en-us/dotnet/aspire/database/sql-server-component?branch=pr-en-us-231) |


<!-- PREVIEW-TABLE-END -->