### PR TITLE
Update sql-server-component.md

### DIFF
--- a/docs/database/sql-server-component.md
+++ b/docs/database/sql-server-component.md
@@ -130,10 +130,10 @@ Here are the configurable options with corresponding default values:
 
 ## Orchestration
 
-In your AppHost project, register a SqlServer database and consume the connection using the following methods:
+In your AppHost project, register a SqlServer container and consume the connection using the following methods:
 
 ```csharp
-var sql = builder.AddSqlServer("sql")
+var sql = builder.AddSqlServerContainer("sql")
                  .AddDatabase("sqldata");
 
 var myService = builder.AddProject<Projects.MyService>()


### PR DESCRIPTION
## Summary

Based on the NuGet package Readme.md file `AddSqlServer` should be changed to `AddSqlServerContainer` because there is no method name `AddSqlServer`


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/database/sql-server-component.md](https://github.com/dotnet/docs-aspire/blob/130118cdd9537164f9a25cdfd38bcd438033b554/docs/database/sql-server-component.md) | [.NET Aspire SQL Server component](https://review.learn.microsoft.com/en-us/dotnet/aspire/database/sql-server-component?branch=pr-en-us-295) |

<!-- PREVIEW-TABLE-END -->