### PR TITLE
Removed unused variable from "Tutorial: Connect an ASP.NET Core app to SQL Server using .NET Aspire and Entity Framework Core"

### DIFF
--- a/docs/database/snippets/tutorial/aspiresqlefcore/AspireSQLEFCore.AppHost/Program.cs
+++ b/docs/database/snippets/tutorial/aspiresqlefcore/AspireSQLEFCore.AppHost/Program.cs
@@ -1,7 +1,5 @@
 ﻿var builder = DistributedApplication.CreateBuilder(args);
 
-var sqlpassword = builder.Configuration["sqlpassword"];
-
 var sql = builder.AddSqlServer("sql")
                  .AddDatabase("sqldata");
 

--- a/docs/database/sql-server-components.md
+++ b/docs/database/sql-server-components.md
@@ -98,13 +98,7 @@ Replace the contents of the _Program.cs_ file in the _AspireSQLEFCore.AppHost_ p
 
 :::code language="csharp" source="snippets/tutorial/AspireSQLEFCore/AspireSQLEFCore.AppHost/Program.cs":::
 
-The preceding code adds a SQL Server Container resource to your app and configures a connection to a database called `sqldata`. The Entity Framework classes you configured earlier will automatically use this connection when migrating and connecting to the database. The `sqlpassword` variable represents the password for the default database user in the SQL Server container.
-
-Set a `sqlpassword` key in the [user secrets](/aspnet/core/security/app-secrets) store of the _AspireSQLEFCore.AppHost_ project using the `dotnet user-secrets` command in the AppHost project directory. Passwords must meet the [Password Policy](/sql/relational-databases/security/password-policy#password-complexity) complexity requirements.
-
-```dotnetcli
-dotnet user-secrets set sqlpassword <password>
-```
+The preceding code adds a SQL Server Container resource to your app and configures a connection to a database called `sqldata`. The Entity Framework classes you configured earlier will automatically use this connection when migrating and connecting to the database.
 
 ## Run and test the app locally
 


### PR DESCRIPTION
## Summary

Removed unused variable called `sqlpassword` and all mentions of it from both the text and the code:
![image](https://github.com/dotnet/docs-aspire/assets/44908454/b8ab0239-0cfc-44f4-9778-d867d0f5cd57)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/database/sql-server-components.md](https://github.com/dotnet/docs-aspire/blob/affb2741ab09a014ef2809c6aa75d38fa1f14fa8/docs/database/sql-server-components.md) | [Tutorial: Connect an ASP.NET Core app to SQL Server using .NET Aspire and Entity Framework Core](https://review.learn.microsoft.com/en-us/dotnet/aspire/database/sql-server-components?branch=pr-en-us-323) |

<!-- PREVIEW-TABLE-END -->