### PR TITLE
removing static keyword from HttpClient lambda

### DIFF
--- a/docs/get-started/snippets/quickstart/AspireSample/AspireSample.Web/Program.cs
+++ b/docs/get-started/snippets/quickstart/AspireSample/AspireSample.Web/Program.cs
@@ -12,7 +12,7 @@ builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();
 
 builder.Services.AddHttpClient<WeatherApiClient>(
-    static client=> client.BaseAddress = new("http://apiservice"));
+    client => client.BaseAddress = new("http://apiservice"));
 
 var app = builder.Build();
 


### PR DESCRIPTION
## Summary

removes the static keyword from HttpClient lambda in the Web project to align with the [latest version of the starter project template](https://github.com/dotnet/aspire/blob/f2d158bf2b02e370a6c0714313823e5a612ab962/src/Aspire.ProjectTemplates/templates/aspire-starter/AspireStarterApplication.1.Web/Program.cs#L20-L24)