### PR TITLE
Update Visual Studio 2022 version.

### DIFF
--- a/docs/fundamentals/setup-tooling.md
+++ b/docs/fundamentals/setup-tooling.md
@@ -23,7 +23,7 @@ To work with .NET Aspire, you'll need the following installed locally:
 - [.NET Aspire workload](/dotnet/core/tools/dotnet-workload-install)
 - [Docker Desktop](https://www.docker.com/products/docker-desktop/)
 - Integrated Developer Environment (IDE) or code editor, such as:
-  - [Visual Studio 2022 Preview](https://visualstudio.microsoft.com/vs/preview/) version 17.9 or higher (Optional)
+  - [Visual Studio 2022 Preview](https://visualstudio.microsoft.com/vs/preview/) version 17.10 or higher (Optional)
   - [Visual Studio Code](https://code.visualstudio.com/) (Optional)
 
 The .NET Aspire workload installs internal dependencies and makes available other tooling, such as project templates and Visual Studio features. There are two ways to install the .NET Aspire workload. If you prefer to use Visual Studio Code, follow the .NET CLI instructions:

--- a/docs/includes/aspire-prereqs.md
+++ b/docs/includes/aspire-prereqs.md
@@ -8,7 +8,7 @@ To work with .NET Aspire, you need the following installed locally:
   - [Use the `dotnet workload install aspire` command](../fundamentals/setup-tooling.md?tabs=dotnet-cli#install-net-aspire)
 - [Docker Desktop](https://www.docker.com/products/docker-desktop/)
 - Integrated Developer Environment (IDE) or code editor, such as:
-  - [Visual Studio 2022 Preview](https://visualstudio.microsoft.com/vs/preview/) version 17.9 or higher (Optional)
+  - [Visual Studio 2022 Preview](https://visualstudio.microsoft.com/vs/preview/) version 17.10 or higher (Optional)
   - [Visual Studio Code](https://code.visualstudio.com/) (Optional)
 
 For more information, see [.NET Aspire setup and tooling](../fundamentals/setup-tooling.md).


### PR DESCRIPTION
## Summary
Since Aspire is included in 17.10, so I think we should update in other places as well.

Describe your changes here.
Update VS version

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/setup-tooling.md](https://github.com/dotnet/docs-aspire/blob/6746df6a679dd4c888ced5fa51eddf6f57302de0/docs/fundamentals/setup-tooling.md) | [.NET Aspire setup and tooling](https://review.learn.microsoft.com/en-us/dotnet/aspire/fundamentals/setup-tooling?branch=pr-en-us-381) |

<!-- PREVIEW-TABLE-END -->