### PR TITLE
Remove obsolete APIs

### DIFF
--- a/docs/deployment/manifest-format.md
+++ b/docs/deployment/manifest-format.md
@@ -1,7 +1,7 @@
 ---
 title: .NET Aspire manifest format for deployment tool builders
 description: Learn about the .NET Aspire manifest format in this comprehensive deployment tool builder guide.
-ms.date: 12/20/2023
+ms.date: 02/14/2024
 ms.topic: reference
 ---
 
@@ -278,7 +278,7 @@ var builder = DistributedApplication.CreateBuilder(args);
 
 builder.AddContainer("mycontainer", "myimage")
        .WithEnvironment("LOG_LEVEL", "WARN")
-       .WithServiceBinding(3000, scheme: "http");
+       .WithHttpEndpoint(3000);
 ```
 
 Example manifest:
@@ -313,7 +313,7 @@ Example code:
 var builder = DistributedApplication.CreateBuilder(args);
 
 builder.AddNodeApp("nodeapp", "../nodeapp/app.js")
-       .WithServiceBinding(hostPort: 5031, scheme: "http", env: "PORT")
+       .WithHttpEndpoint(hostPort: 5031, env: "PORT")
        .AsDockerfileInManifest();
 ```
 

--- a/docs/fundamentals/app-host-overview.md
+++ b/docs/fundamentals/app-host-overview.md
@@ -1,7 +1,7 @@
 ---
 title: .NET Aspire orchestration overview
 description: Learn the fundamental concepts of .NET Aspire orchestration and explore the various APIs to express resource references.
-ms.date: 02/14/2024
+ms.date: 02/15/2024
 ms.topic: overview
 ---
 
@@ -99,7 +99,7 @@ Project-to-project references are handled differently than resources that have w
 
 Adding a reference to the "apiservice" project results in service discovery environment variables being added to the front-end. This is because typically, project to project communication occurs over HTTP/gRPC. For more information, see [.NET Aspire service discovery](../service-discovery/overview.md).
 
-It's possible to get specific endpoints from a container or executable using the <xref:Aspire.Hosting.ResourceBuilderExtensions.WithServiceBinding%2A> and calling the <xref:Aspire.Hosting.ApplicationModel.IResourceWithBindings.GetEndpoint%2A>:
+It's possible to get specific endpoints from a container or executable using the <xref:Aspire.Hosting.ContainerResourceBuilderExtensions.AddContainer%2A> and calling the <xref:Aspire.Hosting.ApplicationModel.IResourceWithBindings.GetEndpoint%2A>:
 
 ```csharp
 var customContainer = builder.AddContainer("myapp", "mycustomcontainer")

--- a/docs/fundamentals/app-host-overview.md
+++ b/docs/fundamentals/app-host-overview.md
@@ -99,7 +99,7 @@ Project-to-project references are handled differently than resources that have w
 
 Adding a reference to the "apiservice" project results in service discovery environment variables being added to the front-end. This is because typically, project to project communication occurs over HTTP/gRPC. For more information, see [.NET Aspire service discovery](../service-discovery/overview.md).
 
-It's possible to get specific endpoints from a container or executable using the <xref:Aspire.Hosting.ContainerResourceBuilderExtensions.AddContainer%2A> and calling the <xref:Aspire.Hosting.ApplicationModel.IResourceWithBindings.GetEndpoint%2A>:
+It's possible to get specific endpoints from a container or executable using the <xref:Aspire.Hosting.ResourceBuilderExtensions.WithEndpoint%2A> and calling the <xref:Aspire.Hosting.ApplicationModel.IResourceWithEndpoints.GetEndpoint%2A>:
 
 ```csharp
 var customContainer = builder.AddContainer("myapp", "mycustomcontainer")

--- a/docs/fundamentals/app-host-overview.md
+++ b/docs/fundamentals/app-host-overview.md
@@ -1,7 +1,7 @@
 ---
 title: .NET Aspire orchestration overview
 description: Learn the fundamental concepts of .NET Aspire orchestration and explore the various APIs to express resource references.
-ms.date: 12/11/2023
+ms.date: 02/14/2024
 ms.topic: overview
 ---
 
@@ -103,7 +103,7 @@ It's possible to get specific endpoints from a container or executable using the
 
 ```csharp
 var customContainer = builder.AddContainer("myapp", "mycustomcontainer")
-                             .WithServiceBinding(containerPort: 9043, name: "endpoint");
+                             .WithEndpoint(containerPort: 9043, name: "endpoint");
 
 var endpoint = customContainer.GetEndpoint("endpoint");
 

--- a/docs/fundamentals/snippets/networking/Networking.AppHost/Program.ContainerPort.cs
+++ b/docs/fundamentals/snippets/networking/Networking.AppHost/Program.ContainerPort.cs
@@ -4,7 +4,7 @@
     {
         // <containerport>
         builder.AddContainer("frontend", "mcr.microsoft.com/dotnet/samples", "aspnetapp")
-               .WithServiceBinding(hostPort: 8000, containerPort: 8080, scheme: "http");
+               .WithHttpEndpoint(hostPort: 8000, containerPort: 8080);
         // </containerport>
     }
 }

--- a/docs/fundamentals/snippets/networking/Networking.AppHost/Program.EnvVarPort.cs
+++ b/docs/fundamentals/snippets/networking/Networking.AppHost/Program.EnvVarPort.cs
@@ -4,7 +4,7 @@
     {
         // <envvarport>
         builder.AddNpmApp("frontend", "../NodeFrontend", "watch")
-               .WithServiceBinding(hostPort: 5067, scheme: "http", env: "PORT");
+               .WithHttpEndpoint(hostPort: 5067, env: "PORT");
         // </envvarport>
     }
 }

--- a/docs/fundamentals/snippets/networking/Networking.AppHost/Program.HostPortAndRandomPort.cs
+++ b/docs/fundamentals/snippets/networking/Networking.AppHost/Program.HostPortAndRandomPort.cs
@@ -4,7 +4,7 @@
     {
         // <hostport>
         builder.AddProject<Projects.Networking_Frontend>("frontend")
-               .WithServiceBinding(hostPort: 5066, scheme: "http");
+               .WithHttpEndpoint(hostPort: 5066);
         // </hostport>
     }
 }

--- a/docs/fundamentals/snippets/networking/Networking.AppHost/Program.OmitHostPort.cs
+++ b/docs/fundamentals/snippets/networking/Networking.AppHost/Program.OmitHostPort.cs
@@ -4,7 +4,7 @@
     {
         // <omithostport>
         builder.AddProject<Projects.Networking_Frontend>("frontend")
-               .WithServiceBinding(scheme: "http");
+               .WithHttpEndpoint();
         // </omithostport>
     }
 }

--- a/docs/fundamentals/snippets/networking/Networking.AppHost/Program.WithLaunchProfile.cs
+++ b/docs/fundamentals/snippets/networking/Networking.AppHost/Program.WithLaunchProfile.cs
@@ -9,8 +9,8 @@
 
         // <verbose>
         builder.AddProject<Projects.Networking_Frontend>("frontend")
-               .WithServiceBinding(hostPort: 5066, scheme: "http")
-               .WithServiceBinding(hostPort: 7239, scheme: "https");
+               .WithHttpEndpoint(hostPort: 5066)
+               .WithHttpsEndpoint(hostPort: 7239);
         // </verbose>
     }
 }

--- a/docs/fundamentals/snippets/networking/Networking.AppHost/Program.WithReplicas.cs
+++ b/docs/fundamentals/snippets/networking/Networking.AppHost/Program.WithReplicas.cs
@@ -4,7 +4,7 @@
     {
         // <withreplicas>
         builder.AddProject<Projects.Networking_Frontend>("frontend")
-               .WithServiceBinding(hostPort: 5066, scheme: "http")
+               .WithHttpEndpoint(hostPort: 5066)
                .WithReplicas(2);
         // </withreplicas>
     }

--- a/docs/service-discovery/overview.md
+++ b/docs/service-discovery/overview.md
@@ -1,7 +1,7 @@
 ---
 title: .NET Aspire service discovery
 description: Understand essential service discovery concepts in .NET Aspire.
-ms.date: 12/08/2023
+ms.date: 02/14/2024
 ms.topic: quickstart
 ---
 
@@ -64,7 +64,7 @@ In the preceding JSON:
 
 ```csharp
 var basket = builder.AddProject<Projects.BasketService>("basket")
-    .WithServiceBinding(hostPort: 8888, scheme: "http", name: "dashboard");
+    .WithHttpEndpoint(hostPort: 8888, name: "dashboard");
 ```
 
 ### Named endpoints in Kubernetes using DNS SRV


### PR DESCRIPTION
## Summary

Remove obsolete APIs, still waiting on `xref` indexing.

Fixes #388


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/deployment/manifest-format.md](https://github.com/dotnet/docs-aspire/blob/fcec0ad24670f1afde15d356a33c96ce8281952e/docs/deployment/manifest-format.md) | [.NET Aspire manifest format for deployment tool builders](https://review.learn.microsoft.com/en-us/dotnet/aspire/deployment/manifest-format?branch=pr-en-us-389) |
| [docs/fundamentals/app-host-overview.md](https://github.com/dotnet/docs-aspire/blob/fcec0ad24670f1afde15d356a33c96ce8281952e/docs/fundamentals/app-host-overview.md) | [.NET Aspire orchestration overview](https://review.learn.microsoft.com/en-us/dotnet/aspire/fundamentals/app-host-overview?branch=pr-en-us-389) |
| [docs/service-discovery/overview.md](https://github.com/dotnet/docs-aspire/blob/fcec0ad24670f1afde15d356a33c96ce8281952e/docs/service-discovery/overview.md) | [.NET Aspire service discovery](https://review.learn.microsoft.com/en-us/dotnet/aspire/service-discovery/overview?branch=pr-en-us-389) |


<!-- PREVIEW-TABLE-END -->