### PR TITLE
Add content covering `WithEndpoint` and the `callback` delegate.

### DIFF
--- a/docs/fundamentals/networking-overview.md
+++ b/docs/fundamentals/networking-overview.md
@@ -151,7 +151,7 @@ There's also an overload that allows you to specify a delegate to configure the 
 
 :::code source="snippets/networking/Networking.AppHost/Program.WithEndpoint.cs" id="withendpoint":::
 
-The preceding code provides a callback delegate to configure the endpoint. The endpoint is named `admin` and configured to use the `http` scheme, and 17003 host port. The consumer references this endpoint by name, consider the following `AddHttpClient` call:
+The preceding code provides a callback delegate to configure the endpoint. The endpoint is named `admin` and configured to use the `http` scheme and transport, as well as the 17003 host port. The consumer references this endpoint by name, consider the following `AddHttpClient` call:
 
 ```
 builder.Services.AddHttpClient<WeatherApiClient>(

--- a/docs/fundamentals/networking-overview.md
+++ b/docs/fundamentals/networking-overview.md
@@ -1,7 +1,7 @@
 ---
 title: .NET Aspire inner loop networking overview
 description: Learn how .NET Aspire handles networking and service bindings, and how you can use them in your app code.
-ms.date: 01/12/2024
+ms.date: 03/05/2024
 ms.topic: overview
 ---
 
@@ -142,3 +142,13 @@ The preceding code:
 Consider the following diagram:
 
 :::image type="content" source="media/networking/proxy-with-docker-port-mapping-1x.png" alt-text=".NET Aspire frontend app networking diagram with a docker host.":::
+
+## Endpoint extension methods
+
+Any resource that implements the `IResourceWithEndpoints` interface can use the `WithEndpoint` extension methods. There are several overloads of this extension, allowing you to specify the scheme, container port, host port, environment variable name, and whether the endpoint is proxied.
+
+There's also an overload that allows you to specify a delegate to configure the endpoint. This is useful when you need to configure the endpoint based on the environment or other factors. Consider the following code:
+
+:::code source="snippets/networking/Networking.AppHost/Program.WithEndpoint.cs" id="withendpoint":::
+
+The preceding code provides a callback delegate to configure the endpoint.

--- a/docs/fundamentals/networking-overview.md
+++ b/docs/fundamentals/networking-overview.md
@@ -1,7 +1,7 @@
 ---
 title: .NET Aspire inner loop networking overview
 description: Learn how .NET Aspire handles networking and service bindings, and how you can use them in your app code.
-ms.date: 03/05/2024
+ms.date: 03/07/2024
 ms.topic: overview
 ---
 
@@ -151,4 +151,11 @@ There's also an overload that allows you to specify a delegate to configure the 
 
 :::code source="snippets/networking/Networking.AppHost/Program.WithEndpoint.cs" id="withendpoint":::
 
-The preceding code provides a callback delegate to configure the endpoint.
+The preceding code provides a callback delegate to configure the endpoint. The endpoint is named `admin` and configured to use the `http` scheme, and 17003 host port. The consumer references this endpoint by name, consider the following `AddHttpClient` call:
+
+```
+builder.Services.AddHttpClient<WeatherApiClient>(
+    client => client.BaseAddress = new Uri("http://_admin.apiservice"));
+```
+
+The `Uri` is constructed using the `admin` endpoint name prefixed with the `_` sentinel. This is a convention to indicate that the `admin` segment is the endpoint name belonging to the `apiservice` service. For more information, see [.NET Aspire service discovery](../service-discovery/overview.md).

--- a/docs/fundamentals/snippets/networking/Networking.ApiService/Networking.ApiService.csproj
+++ b/docs/fundamentals/snippets/networking/Networking.ApiService/Networking.ApiService.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Networking.ServiceDefaults\Networking.ServiceDefaults.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/docs/fundamentals/snippets/networking/Networking.ApiService/Networking.ApiService.http
+++ b/docs/fundamentals/snippets/networking/Networking.ApiService/Networking.ApiService.http
@@ -1,0 +1,6 @@
+@Networking.ApiService_HostAddress = http://localhost:5182
+
+GET {{Networking.ApiService_HostAddress}}/weatherforecast/
+Accept: application/json
+
+###

--- a/docs/fundamentals/snippets/networking/Networking.ApiService/Program.cs
+++ b/docs/fundamentals/snippets/networking/Networking.ApiService/Program.cs
@@ -1,0 +1,35 @@
+﻿var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+builder.AddServiceDefaults();
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+
+app.UseHttpsRedirection();
+
+var summaries = new[]
+{
+    "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+};
+
+app.MapGet("/weatherforecast", () =>
+{
+    var forecast =  Enumerable.Range(1, 5).Select(index =>
+        new WeatherForecast
+        (
+            DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
+            Random.Shared.Next(-20, 55),
+            summaries[Random.Shared.Next(summaries.Length)]
+        ))
+        .ToArray();
+    return forecast;
+});
+
+app.Run();
+
+record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
+{
+    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+}

--- a/docs/fundamentals/snippets/networking/Networking.ApiService/Properties/launchSettings.json
+++ b/docs/fundamentals/snippets/networking/Networking.ApiService/Properties/launchSettings.json
@@ -1,0 +1,41 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:1651",
+      "sslPort": 44364
+    }
+  },
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "weatherforecast",
+      "applicationUrl": "http://localhost:5182",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "weatherforecast",
+      "applicationUrl": "https://localhost:7141;http://localhost:5182",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "weatherforecast",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/docs/fundamentals/snippets/networking/Networking.ApiService/appsettings.Development.json
+++ b/docs/fundamentals/snippets/networking/Networking.ApiService/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/docs/fundamentals/snippets/networking/Networking.ApiService/appsettings.json
+++ b/docs/fundamentals/snippets/networking/Networking.ApiService/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/docs/fundamentals/snippets/networking/Networking.AppHost/Networking.AppHost.csproj
+++ b/docs/fundamentals/snippets/networking/Networking.AppHost/Networking.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -13,6 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Networking.ApiService\Networking.ApiService.csproj" />
     <ProjectReference Include="..\Networking.Frontend\Networking.Frontend\Networking.Frontend.csproj" />
   </ItemGroup>
 

--- a/docs/fundamentals/snippets/networking/Networking.AppHost/Program.WithEndpoint.cs
+++ b/docs/fundamentals/snippets/networking/Networking.AppHost/Program.WithEndpoint.cs
@@ -10,6 +10,7 @@
                {
                    endpoint.Port = 17003;
                    endpoint.UriScheme = "http";
+                   endpoint.Transport = "http";
                });
         // </withendpoint>
     }

--- a/docs/fundamentals/snippets/networking/Networking.AppHost/Program.WithEndpoint.cs
+++ b/docs/fundamentals/snippets/networking/Networking.AppHost/Program.WithEndpoint.cs
@@ -1,0 +1,15 @@
+﻿public static partial class Program
+{
+    public static void WithEndpoint(IDistributedApplicationBuilder builder)
+    {
+        // <withendpoint>
+        builder.AddProject<Projects.Networking_Frontend>("frontend")
+               .WithEndpoint(
+                    endpointName: "frontendEndpoint",
+                    callback: static endpoint =>
+               {
+                   // Configure the endpoint instance directly
+               });
+        // </withendpoint>
+    }
+}

--- a/docs/fundamentals/snippets/networking/Networking.AppHost/Program.WithEndpoint.cs
+++ b/docs/fundamentals/snippets/networking/Networking.AppHost/Program.WithEndpoint.cs
@@ -3,12 +3,14 @@
     public static void WithEndpoint(IDistributedApplicationBuilder builder)
     {
         // <withendpoint>
-        builder.AddProject<Projects.Networking_Frontend>("frontend")
+        builder.AddProject<Projects.Networking_ApiService>("apiService")
                .WithEndpoint(
-                    endpointName: "frontendEndpoint",
+                    endpointName: "FixedAndExternal",
                     callback: static endpoint =>
                {
-                   // Configure the endpoint instance directly
+                   endpoint.Port = 17003;
+                   endpoint.AsHttp2()
+                           .AsExternal();
                });
         // </withendpoint>
     }

--- a/docs/fundamentals/snippets/networking/Networking.AppHost/Program.WithEndpoint.cs
+++ b/docs/fundamentals/snippets/networking/Networking.AppHost/Program.WithEndpoint.cs
@@ -5,12 +5,11 @@
         // <withendpoint>
         builder.AddProject<Projects.Networking_ApiService>("apiService")
                .WithEndpoint(
-                    endpointName: "FixedAndExternal",
+                    endpointName: "admin",
                     callback: static endpoint =>
                {
                    endpoint.Port = 17003;
-                   endpoint.AsHttp2()
-                           .AsExternal();
+                   endpoint.UriScheme = "http";
                });
         // </withendpoint>
     }

--- a/docs/fundamentals/snippets/networking/Networking.AppHost/Program.cs
+++ b/docs/fundamentals/snippets/networking/Networking.AppHost/Program.cs
@@ -1,6 +1,17 @@
 ﻿var builder = DistributedApplication.CreateBuilder(args);
 
-WithEndpoint(builder);
+var apiService = builder.AddProject<Projects.Networking_ApiService>("apiService")
+    .WithEndpoint("external", static endpoint =>
+    {
+        endpoint.Port = 17003;
+        endpoint.IsExternal = true;
+        endpoint.AsHttp2();
+    });
+
+builder.AddProject<Projects.Networking_Frontend>("frontend")
+       .WithReference(apiService);
+
+// WithEndpoint(builder);
 // ContainerPort(builder);
 // EnvVarPort(builder);
 // HostPortWithRandomServicePort(builder);

--- a/docs/fundamentals/snippets/networking/Networking.AppHost/Program.cs
+++ b/docs/fundamentals/snippets/networking/Networking.AppHost/Program.cs
@@ -1,11 +1,10 @@
 ﻿var builder = DistributedApplication.CreateBuilder(args);
 
 var apiService = builder.AddProject<Projects.Networking_ApiService>("apiService")
-    .WithEndpoint("external", static endpoint =>
+    .WithEndpoint("admin", static endpoint =>
     {
         endpoint.Port = 17003;
-        endpoint.IsExternal = true;
-        endpoint.AsHttp2();
+        endpoint.UriScheme = "http";
     });
 
 builder.AddProject<Projects.Networking_Frontend>("frontend")

--- a/docs/fundamentals/snippets/networking/Networking.AppHost/Program.cs
+++ b/docs/fundamentals/snippets/networking/Networking.AppHost/Program.cs
@@ -5,6 +5,7 @@ var apiService = builder.AddProject<Projects.Networking_ApiService>("apiService"
     {
         endpoint.Port = 17003;
         endpoint.UriScheme = "http";
+        endpoint.Transport = "http";
     });
 
 builder.AddProject<Projects.Networking_Frontend>("frontend")

--- a/docs/fundamentals/snippets/networking/Networking.AppHost/Program.cs
+++ b/docs/fundamentals/snippets/networking/Networking.AppHost/Program.cs
@@ -1,5 +1,6 @@
 ﻿var builder = DistributedApplication.CreateBuilder(args);
 
+WithEndpoint(builder);
 // ContainerPort(builder);
 // EnvVarPort(builder);
 // HostPortWithRandomServicePort(builder);

--- a/docs/fundamentals/snippets/networking/Networking.Frontend/Networking.Frontend/Components/Pages/Weather.razor
+++ b/docs/fundamentals/snippets/networking/Networking.Frontend/Networking.Frontend/Components/Pages/Weather.razor
@@ -9,7 +9,7 @@
 
 <p>This component demonstrates showing data.</p>
 
-@if (forecasts == null)
+@if (forecasts is null or { Count: 0 })
 {
     <p><em>Loading...</em></p>
 }
@@ -39,10 +39,18 @@ else
 }
 
 @code {
-    private WeatherForecast[]? forecasts;
+    private List<WeatherForecast> forecasts = [];
 
     protected override async Task OnInitializedAsync()
     {
-        forecasts = await WeatherApi.GetWeatherAsync();
+        await foreach (var forecast in WeatherApi.GetWeatherAsync())
+        {
+            if (forecast is null)
+            {
+                continue;
+            }
+
+            forecasts.Add(forecast);
+        }
     }
 }

--- a/docs/fundamentals/snippets/networking/Networking.Frontend/Networking.Frontend/Components/Pages/Weather.razor
+++ b/docs/fundamentals/snippets/networking/Networking.Frontend/Networking.Frontend/Components/Pages/Weather.razor
@@ -1,6 +1,8 @@
 ﻿@page "/weather"
 @attribute [StreamRendering]
 
+@inject WeatherApiClient WeatherApi
+
 <PageTitle>Weather</PageTitle>
 
 <h1>Weather</h1>
@@ -41,24 +43,6 @@ else
 
     protected override async Task OnInitializedAsync()
     {
-        // Simulate asynchronous loading to demonstrate streaming rendering
-        await Task.Delay(500);
-
-        var startDate = DateOnly.FromDateTime(DateTime.Now);
-        var summaries = new[] { "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching" };
-        forecasts = Enumerable.Range(1, 5).Select(index => new WeatherForecast
-        {
-            Date = startDate.AddDays(index),
-            TemperatureC = Random.Shared.Next(-20, 55),
-            Summary = summaries[Random.Shared.Next(summaries.Length)]
-        }).ToArray();
-    }
-
-    private class WeatherForecast
-    {
-        public DateOnly Date { get; set; }
-        public int TemperatureC { get; set; }
-        public string? Summary { get; set; }
-        public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+        forecasts = await WeatherApi.GetWeatherAsync();
     }
 }

--- a/docs/fundamentals/snippets/networking/Networking.Frontend/Networking.Frontend/Networking.Frontend.csproj
+++ b/docs/fundamentals/snippets/networking/Networking.Frontend/Networking.Frontend/Networking.Frontend.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\Networking.ServiceDefaults\Networking.ServiceDefaults.csproj" />
     <ProjectReference Include="..\Networking.Frontend.Client\Networking.Frontend.Client.csproj" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.2" />
   </ItemGroup>

--- a/docs/fundamentals/snippets/networking/Networking.Frontend/Networking.Frontend/Program.cs
+++ b/docs/fundamentals/snippets/networking/Networking.Frontend/Networking.Frontend/Program.cs
@@ -10,7 +10,7 @@ builder.Services.AddRazorComponents()
     .AddInteractiveWebAssemblyComponents();
 
 builder.Services.AddHttpClient<WeatherApiClient>(
-    client => client.BaseAddress = new("http://external"));
+    client => client.BaseAddress = new("http://_admin.apiservice"));
 
 var app = builder.Build();
 

--- a/docs/fundamentals/snippets/networking/Networking.Frontend/Networking.Frontend/Program.cs
+++ b/docs/fundamentals/snippets/networking/Networking.Frontend/Networking.Frontend/Program.cs
@@ -1,11 +1,16 @@
-using Networking.Frontend.Client.Pages;
+﻿using Networking.Frontend.Client.Pages;
 using Networking.Frontend.Components;
 
 var builder = WebApplication.CreateBuilder(args);
 
+builder.AddServiceDefaults();
+
 // Add services to the container.
 builder.Services.AddRazorComponents()
     .AddInteractiveWebAssemblyComponents();
+
+builder.Services.AddHttpClient<WeatherApiClient>(
+    client => client.BaseAddress = new("http://external"));
 
 var app = builder.Build();
 

--- a/docs/fundamentals/snippets/networking/Networking.Frontend/Networking.Frontend/WeatherApiClient.cs
+++ b/docs/fundamentals/snippets/networking/Networking.Frontend/Networking.Frontend/WeatherApiClient.cs
@@ -1,8 +1,8 @@
 ﻿public class WeatherApiClient(HttpClient httpClient)
 {
-    public async Task<WeatherForecast[]> GetWeatherAsync()
+    public IAsyncEnumerable<WeatherForecast?> GetWeatherAsync()
     {
-        return await httpClient.GetFromJsonAsync<WeatherForecast[]>("/weatherforecast") ?? [];
+        return httpClient.GetFromJsonAsAsyncEnumerable<WeatherForecast>("/weatherforecast");
     }
 }
 

--- a/docs/fundamentals/snippets/networking/Networking.Frontend/Networking.Frontend/WeatherApiClient.cs
+++ b/docs/fundamentals/snippets/networking/Networking.Frontend/Networking.Frontend/WeatherApiClient.cs
@@ -1,0 +1,12 @@
+﻿public class WeatherApiClient(HttpClient httpClient)
+{
+    public async Task<WeatherForecast[]> GetWeatherAsync()
+    {
+        return await httpClient.GetFromJsonAsync<WeatherForecast[]>("/weatherforecast") ?? [];
+    }
+}
+
+public record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
+{
+    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+}

--- a/docs/fundamentals/snippets/networking/Networking.ServiceDefaults/Extensions.cs
+++ b/docs/fundamentals/snippets/networking/Networking.ServiceDefaults/Extensions.cs
@@ -1,0 +1,117 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+using OpenTelemetry.Logs;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
+namespace Microsoft.Extensions.Hosting;
+public static class Extensions
+{
+    public static IHostApplicationBuilder AddServiceDefaults(this IHostApplicationBuilder builder)
+    {
+        builder.ConfigureOpenTelemetry();
+
+        builder.AddDefaultHealthChecks();
+
+        builder.Services.AddServiceDiscovery();
+
+        builder.Services.ConfigureHttpClientDefaults(http =>
+        {
+            // Turn on resilience by default
+            http.AddStandardResilienceHandler();
+
+            // Turn on service discovery by default
+            http.UseServiceDiscovery();
+        });
+
+        return builder;
+    }
+
+    public static IHostApplicationBuilder ConfigureOpenTelemetry(this IHostApplicationBuilder builder)
+    {
+        builder.Logging.AddOpenTelemetry(logging =>
+        {
+            logging.IncludeFormattedMessage = true;
+            logging.IncludeScopes = true;
+        });
+
+        builder.Services.AddOpenTelemetry()
+            .WithMetrics(metrics =>
+            {
+                metrics.AddAspNetCoreInstrumentation()
+                       .AddHttpClientInstrumentation()
+                       .AddProcessInstrumentation()
+                       .AddRuntimeInstrumentation();
+            })
+            .WithTracing(tracing =>
+            {
+                if (builder.Environment.IsDevelopment())
+                {
+                    // We want to view all traces in development
+                    tracing.SetSampler(new AlwaysOnSampler());
+                }
+
+                tracing.AddAspNetCoreInstrumentation()
+                       .AddGrpcClientInstrumentation()
+                       .AddHttpClientInstrumentation();
+            });
+
+        builder.AddOpenTelemetryExporters();
+
+        return builder;
+    }
+
+    private static IHostApplicationBuilder AddOpenTelemetryExporters(this IHostApplicationBuilder builder)
+    {
+        var useOtlpExporter = !string.IsNullOrWhiteSpace(builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"]);
+
+        if (useOtlpExporter)
+        {
+            builder.Services.Configure<OpenTelemetryLoggerOptions>(logging => logging.AddOtlpExporter());
+            builder.Services.ConfigureOpenTelemetryMeterProvider(metrics => metrics.AddOtlpExporter());
+            builder.Services.ConfigureOpenTelemetryTracerProvider(tracing => tracing.AddOtlpExporter());
+        }
+
+        // Uncomment the following lines to enable the Prometheus exporter (requires the OpenTelemetry.Exporter.Prometheus.AspNetCore package)
+        // builder.Services.AddOpenTelemetry()
+        //    .WithMetrics(metrics => metrics.AddPrometheusExporter());
+
+        // Uncomment the following lines to enable the Azure Monitor exporter (requires the Azure.Monitor.OpenTelemetry.AspNetCore package)
+        //if (!string.IsNullOrEmpty(builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"]))
+        //{
+        //    builder.Services.AddOpenTelemetry()
+        //       .UseAzureMonitor();
+        //}
+
+        return builder;
+    }
+
+    public static IHostApplicationBuilder AddDefaultHealthChecks(this IHostApplicationBuilder builder)
+    {
+        builder.Services.AddHealthChecks()
+            // Add a default liveness check to ensure app is responsive
+            .AddCheck("self", () => HealthCheckResult.Healthy(), ["live"]);
+
+        return builder;
+    }
+
+    public static WebApplication MapDefaultEndpoints(this WebApplication app)
+    {
+        // Uncomment the following line to enable the Prometheus endpoint (requires the OpenTelemetry.Exporter.Prometheus.AspNetCore package)
+        // app.MapPrometheusScrapingEndpoint();
+
+        // All health checks must pass for app to be considered ready to accept traffic after starting
+        app.MapHealthChecks("/health");
+
+        // Only health checks tagged with the "live" tag must pass for app to be considered alive
+        app.MapHealthChecks("/alive", new HealthCheckOptions
+        {
+            Predicate = r => r.Tags.Contains("live")
+        });
+
+        return app;
+    }
+}

--- a/docs/fundamentals/snippets/networking/Networking.ServiceDefaults/Networking.ServiceDefaults.csproj
+++ b/docs/fundamentals/snippets/networking/Networking.ServiceDefaults/Networking.ServiceDefaults.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsAspireSharedProject>true</IsAspireSharedProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.2.0" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.0.0-preview.4.24129.7" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.7.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.7.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.7.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.7.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.4" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.7.0" />
+  </ItemGroup>
+
+</Project>

--- a/docs/fundamentals/snippets/networking/networking.sln
+++ b/docs/fundamentals/snippets/networking/networking.sln
@@ -9,6 +9,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Networking.Frontend", "Netw
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Networking.Frontend.Client", "Networking.Frontend\Networking.Frontend.Client\Networking.Frontend.Client.csproj", "{578C3607-BDC7-4D23-8A49-AB83C4C85C50}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Networking.ApiService", "Networking.ApiService\Networking.ApiService.csproj", "{8C64CB82-DD18-4843-907E-388F22656F94}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Networking.ServiceDefaults", "Networking.ServiceDefaults\Networking.ServiceDefaults.csproj", "{056BD629-93FA-4360-AA64-01CFC4E31EC9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +31,14 @@ Global
 		{578C3607-BDC7-4D23-8A49-AB83C4C85C50}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{578C3607-BDC7-4D23-8A49-AB83C4C85C50}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{578C3607-BDC7-4D23-8A49-AB83C4C85C50}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8C64CB82-DD18-4843-907E-388F22656F94}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8C64CB82-DD18-4843-907E-388F22656F94}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8C64CB82-DD18-4843-907E-388F22656F94}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8C64CB82-DD18-4843-907E-388F22656F94}.Release|Any CPU.Build.0 = Release|Any CPU
+		{056BD629-93FA-4360-AA64-01CFC4E31EC9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{056BD629-93FA-4360-AA64-01CFC4E31EC9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{056BD629-93FA-4360-AA64-01CFC4E31EC9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{056BD629-93FA-4360-AA64-01CFC4E31EC9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary

Add content for the `WithEndpoint` that exposes the callback delegate. Also, ensure the networking article uses the `WithHttpEndpoint` and `WithHttpsEndpoint` APIs.

Fixes #426


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/networking-overview.md](https://github.com/dotnet/docs-aspire/blob/c24e0783b5dab27a04c317ee2adccb23f6d73ee8/docs/fundamentals/networking-overview.md) | [.NET Aspire inner-loop networking overview](https://review.learn.microsoft.com/en-us/dotnet/aspire/fundamentals/networking-overview?branch=pr-en-us-472) |


<!-- PREVIEW-TABLE-END -->