### PR TITLE
Add text to make a clear distinction between .NET Aspire orchestratio…

### DIFF
--- a/docs/fundamentals/app-host-overview.md
+++ b/docs/fundamentals/app-host-overview.md
@@ -1,7 +1,7 @@
 ---
 title: .NET Aspire orchestration overview
 description: Learn the fundamental concepts of .NET Aspire orchestration and explore the various APIs to express resource references.
-ms.date: 02/20/2024
+ms.date: 03/10/2024
 ms.topic: overview
 ---
 
@@ -15,6 +15,9 @@ Before continuing, consider some common terminology used in .NET Aspire:
 - **App host/Orchestrator project**: The .NET project that orchestrates the _app model_, named with the _*.AppHost_ suffix (by convention).
 - **Resource**: A [resource](#built-in-resource-types) represents a part of an application whether it be a .NET project, container, or executable, or some other resource like a database, cache, or cloud service (such as a storage service).
 - **Reference**: A reference defines a connection between resources, expressed as a dependency. For more information, see [Reference resources](#reference-resources).
+
+> [!TIP]
+> .NET Aspire's orchestration is designed to enhance your local development experience by simplifying the management of your cloud-native app's configuration and interconnections. While it's an invaluable tool for development, it's not intended to replace production environment systems like Kubernetes, which are specifically designed to excel in that context.
 
 ## Define the app model
 

--- a/docs/fundamentals/app-host-overview.md
+++ b/docs/fundamentals/app-host-overview.md
@@ -16,7 +16,7 @@ Before continuing, consider some common terminology used in .NET Aspire:
 - **Resource**: A [resource](#built-in-resource-types) represents a part of an application whether it be a .NET project, container, or executable, or some other resource like a database, cache, or cloud service (such as a storage service).
 - **Reference**: A reference defines a connection between resources, expressed as a dependency. For more information, see [Reference resources](#reference-resources).
 
-> [!TIP]
+> [!NOTE]
 > .NET Aspire's orchestration is designed to enhance your local development experience by simplifying the management of your cloud-native app's configuration and interconnections. While it's an invaluable tool for development, it's not intended to replace production environment systems like Kubernetes, which are specifically designed to excel in that context.
 
 ## Define the app model

--- a/docs/get-started/aspire-overview.md
+++ b/docs/get-started/aspire-overview.md
@@ -14,7 +14,7 @@ A _distributed application_ is one that uses computational resources across mult
 
 .NET Aspire is designed to improve the experience of building .NET cloud-native apps. It provides a consistent, opinionated set of tools and patterns that help you build and run distributed apps. .NET Aspire is designed to help you with:
 
-- [**Orchestration**](#orchestration): .NET Aspire provides features for running and connecting multi-project applications and their dependencies.
+- [**Orchestration**](#orchestration): .NET Aspire provides features for running and connecting multi-project applications and their dependencies for local development environments.
 - [**Components**](#net-aspire-components): .NET Aspire components are NuGet packages for commonly used services, such as Redis or Postgres, with standardized interfaces ensuring they connect consistently and seamlessly with your app.
 - [**Tooling**](#project-templates-and-tooling): .NET Aspire comes with project templates and tooling experiences for Visual Studio and the [dotnet CLI](/dotnet/core/tools/) help you create and interact with .NET Aspire apps.
 

--- a/docs/get-started/aspire-overview.md
+++ b/docs/get-started/aspire-overview.md
@@ -1,7 +1,7 @@
 ---
 title: .NET Aspire overview
 description: Learn about .NET Aspire, an application stack designed to improve the experience of building cloud-native applications.
-ms.date: 01/22/2024
+ms.date: 03/10/2024
 ---
 
 # .NET Aspire overview
@@ -20,7 +20,7 @@ A _distributed application_ is one that uses computational resources across mult
 
 ## Orchestration
 
-Orchestration refers to the coordination and management of various elements within a cloud-native application. .NET Aspire streamlines the configuration and interconnection of different parts of your cloud-native app.  It provides useful abstractions for managing service discovery, environment variables, and container configurations without having to handle low level implementation details. These abstractions also provide consistent setup patterns across apps with many components and services.
+In .NET Aspire, orchestration primarily focuses on enhancing the local development experience by simplifying the management of your cloud-native app's configuration and interconnections. It's important to note that .NET Aspire's orchestration is not intended to replace the robust systems used in production environments, such as Kubernetes. Instead, it provides a set of abstractions that streamline the setup of service discovery, environment variables, and container configurations, eliminating the need to deal with low-level implementation details. These abstractions ensure a consistent setup pattern across apps with numerous components and services, making it easier to manage complex applications during the development phase.
 
 .NET Aspire orchestration assists with the following concerns:
 


### PR DESCRIPTION
## Summary

Disambiguate with k8s. /cc @davidfowl thoughts on this?

Fixes #478


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/app-host-overview.md](https://github.com/dotnet/docs-aspire/blob/47fe4832291f1f4615b4b6761e61cac86eee88ed/docs/fundamentals/app-host-overview.md) | [.NET Aspire orchestration overview](https://review.learn.microsoft.com/en-us/dotnet/aspire/fundamentals/app-host-overview?branch=pr-en-us-479) |
| [docs/get-started/aspire-overview.md](https://github.com/dotnet/docs-aspire/blob/47fe4832291f1f4615b4b6761e61cac86eee88ed/docs/get-started/aspire-overview.md) | [.NET Aspire overview](https://review.learn.microsoft.com/en-us/dotnet/aspire/get-started/aspire-overview?branch=pr-en-us-479) |


<!-- PREVIEW-TABLE-END -->