### PR TITLE
Add write permissions for pull requests

### DIFF
--- a/.github/workflows/quest-bulk.yml
+++ b/.github/workflows/quest-bulk.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
+      pull-requests: write
+      
     if: ${{ github.repository_owner == 'dotnet' }}
     steps:
       - name: "Print manual bulk import run reason"

--- a/.github/workflows/quest.yml
+++ b/.github/workflows/quest.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
+      pull-requests: write
 
     steps:
       - name: "Print manual run reason"


### PR DESCRIPTION
GitHub permissions are ANDed, not ORed. So, even though the sequester app was given permission to read and write pull requests, the configuration in YAML prevented it.

This ensures that if a PR is tagged as a work item, it will be imported correctly.
