### PR TITLE
Remove AddBuiltInMeters()

### DIFF
--- a/docs/fundamentals/service-defaults.md
+++ b/docs/fundamentals/service-defaults.md
@@ -73,7 +73,8 @@ The `ConfigureOpenTelemetry` method:
 - Adds [.NET Aspire telemetry](telemetry.md) logging to include formatted messages and scopes.
 - Adds OpenTelemetry metrics and tracing that include:
   - Runtime instrumentation metrics.
-  - Builtin meters.
+  - ASP.NET Core instrumentation metrics.
+  - HttpClient instrumentation metrics.
   - In a development environment, the `AlwaysOnSampler` is used to view all traces.
   - Tracing details for ASP.NET Core, gRPC and HTTP instrumentation.
 - Adds OpenTelemetry exporters, by calling `AddOpenTelemetryExporters`.

--- a/docs/fundamentals/snippets/params/Parameters.ServiceDefaults/Extensions.cs
+++ b/docs/fundamentals/snippets/params/Parameters.ServiceDefaults/Extensions.cs
@@ -41,8 +41,9 @@ public static class Extensions
         builder.Services.AddOpenTelemetry()
             .WithMetrics(metrics =>
             {
-                metrics.AddRuntimeInstrumentation()
-                       .AddBuiltInMeters();
+                metrics.AddAspNetCoreInstrumentation()
+                       .AddHttpClientInstrumentation()
+                       .AddRuntimeInstrumentation();
             })
             .WithTracing(tracing =>
             {
@@ -109,10 +110,4 @@ public static class Extensions
 
         return app;
     }
-
-    private static MeterProviderBuilder AddBuiltInMeters(this MeterProviderBuilder meterProviderBuilder) =>
-        meterProviderBuilder.AddMeter(
-            "Microsoft.AspNetCore.Hosting",
-            "Microsoft.AspNetCore.Server.Kestrel",
-            "System.Net.Http");
 }

--- a/docs/fundamentals/snippets/template/YourAppName/Extensions.cs
+++ b/docs/fundamentals/snippets/template/YourAppName/Extensions.cs
@@ -47,8 +47,9 @@ public static class Extensions
         builder.Services.AddOpenTelemetry()
             .WithMetrics(metrics =>
             {
-                metrics.AddRuntimeInstrumentation()
-                       .AddBuiltInMeters();
+                metrics.AddAspNetCoreInstrumentation()
+                       .AddHttpClientInstrumentation()
+                       .AddRuntimeInstrumentation();
             })
             .WithTracing(tracing =>
             {
@@ -133,13 +134,4 @@ public static class Extensions
         return app;
     }
     // </mapdefaultendpoints>
-
-    // <addmeters>
-    private static MeterProviderBuilder AddBuiltInMeters(
-        this MeterProviderBuilder meterProviderBuilder) =>
-        meterProviderBuilder.AddMeter(
-            "Microsoft.AspNetCore.Hosting",
-            "Microsoft.AspNetCore.Server.Kestrel",
-            "System.Net.Http");
-    // </addmeters>
 }


### PR DESCRIPTION
## Summary

Update the documentation to use built-in OpenTelemetry instrumentation.

See https://github.com/dotnet/aspire/pull/2900.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/service-defaults.md](https://github.com/dotnet/docs-aspire/blob/7fc003425f3a76cba6ec07cf6b1464b677d710a3/docs/fundamentals/service-defaults.md) | [.NET Aspire service defaults](https://review.learn.microsoft.com/en-us/dotnet/aspire/fundamentals/service-defaults?branch=pr-en-us-518) |

<!-- PREVIEW-TABLE-END -->