### PR TITLE
Corrected port number description to match associated diagram

### DIFF
--- a/docs/fundamentals/networking-overview.md
+++ b/docs/fundamentals/networking-overview.md
@@ -107,8 +107,8 @@ The previous code makes the random port available in the `PORT` environment vari
 The preceding diagram depicts the following:
 
 - A web browser as an entry point to the app.
-- A host port of 5607.
-- The frontend proxy sitting between the web browser and the frontend service, listening on port 5607.
+- A host port of 5067.
+- The frontend proxy sitting between the web browser and the frontend service, listening on port 5067.
 - The frontend service listening on an environment 65001.
 
 ## Omit the host port


### PR DESCRIPTION
## Summary

Corrected a minor typo in the port numbers at the end of the Ports and proxies section: The diagram shows port 5067, the description said 5607, corrected to 5067 to match the diagram.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/networking-overview.md](https://github.com/dotnet/docs-aspire/blob/0144745c0f158cdbe908e4b297038bedd0a81f54/docs/fundamentals/networking-overview.md) | [.NET Aspire inner-loop networking overview](https://review.learn.microsoft.com/en-us/dotnet/aspire/fundamentals/networking-overview?branch=pr-en-us-573) |

<!-- PREVIEW-TABLE-END -->