### PR TITLE
Correct typo in naming of the directory for azure devops pipeline deployment documentations

### DIFF
--- a/docs/deployment/azure/aca-deployment-github-actions.md
+++ b/docs/deployment/azure/aca-deployment-github-actions.md
@@ -179,9 +179,9 @@ Congratulations! You successfully deployed a .NET Aspire app using the Azure Dev
 
 Although `azd` generated some essential template files for you, the project still needs an Azure Pipelines workflow file to support provisioning and deployments using CI/CD.
 
-1. Create an empty _.ado_ folder at the root of your project. `azd` uses this directory by default to discover Azure Pipelines workflow files.
+1. Create an empty _.azdo_ folder at the root of your project. `azd` uses this directory by default to discover Azure Pipelines workflow files.
 
-1. Inside the new _.ado_ folder, create another folder called _pipelines_ (you'll end up with _.ado/pipelines_).
+1. Inside the new _.azdo_ folder, create another folder called _pipelines_ (you'll end up with _.azdo/pipelines_).
 
 1. Add a new Azure Pipelines workflow file into the new folder named _azure-dev.yml_. The `azd` starter template provides a [Sample Azure Pipelines workflow file](https://github.com/Azure-Samples/azd-starter-bicep/blob/main/.azdo/pipelines/azure-dev.yml) that you can copy into your project.
 


### PR DESCRIPTION

## Summary

directory needs to be `azdo` rather than `ado` 

