### PR TITLE
Correct NuGet package

### DIFF
--- a/docs/deployment/azure/application-insights.md
+++ b/docs/deployment/azure/application-insights.md
@@ -1,7 +1,7 @@
 ---
 title: Use .NET Aspire with Application Insights
 description: Learn how to send .NET Aspire telemetry to Application Insights.
-ms.date: 11/11/2023
+ms.date: 04/12/2024
 ms.topic: how-to
 ---
 
@@ -21,11 +21,11 @@ With this option, an instance of Application Insights will be created for you wh
 
 To use automatic provisioning, you specify a dependency in the app host project, and reference it in each project/resource that needs to send telemetry to Application Insights. The steps include:
 
-- Add a Nuget package reference to `Aspire.Hosting.Azure` in the app host project.
+- Add a Nuget package reference to [Aspire.Hosting.Azure.ApplicationInsights](https://nuget.org/packages/Aspire.Hosting.Azure.ApplicationInsights) in the app host project.
 
 - Update the app host code to use the Application Insights resource, and reference it from each project:
 
-``` csharp
+```csharp
 var builder = DistributedApplication.CreateBuilder(args);
 
 // Automatically provision an Application Insights resource
@@ -55,7 +55,9 @@ If you wish to use an instance of Application Insights that you have provisioned
 ```csharp
 var builder = DistributedApplication.CreateBuilder(args);
 
-var insights = builder.AddConnectionString("myInsightsResource", "APPLICATIONINSIGHTS_CONNECTION_STRING");
+var insights = builder.AddConnectionString(
+    "myInsightsResource",
+    "APPLICATIONINSIGHTS_CONNECTION_STRING");
 
 var apiService = builder.AddProject<Projects.ApiService>("apiservice")
     .WithReference(insights);
@@ -96,6 +98,7 @@ var builder = DistributedApplication.CreateBuilder(args);
 var insights = builder.ExecutionContext.IsPublishMode
     ? builder.AddAzureApplicationInsights("myInsightsResource")
     : builder.AddConnectionString("myInsightsResource", "APPLICATIONINSIGHTS_CONNECTION_STRING");
+
 var apiService = builder.AddProject<Projects.ApiService>("apiservice")
     .WithReference(insights);
 


### PR DESCRIPTION
## Summary

Correct NuGet package for App Insights.

Fixes #649


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/deployment/azure/application-insights.md](https://github.com/dotnet/docs-aspire/blob/ff6fe1f6324ebf875494ada61892cdca3fca69b4/docs/deployment/azure/application-insights.md) | [Use Application Insights for .NET Aspire telemetry](https://review.learn.microsoft.com/en-us/dotnet/aspire/deployment/azure/application-insights?branch=pr-en-us-651) |

<!-- PREVIEW-TABLE-END -->