### PR TITLE
Update azure-storage-components.md

### DIFF
--- a/docs/storage/azure-storage-components.md
+++ b/docs/storage/azure-storage-components.md
@@ -182,7 +182,7 @@ Visual Studio tooling added this line of code to register your new project with 
     dotnet sln AspireStorage.sln add AspireStorage.WorkerService/AspireStorage.WorkerService.csproj
     ```
 
-1. Use the [dotnet add package](/dotnet/core/tools/dotnet-add-package)command to add project reference between the **.AppHost** and **.WorkerService** project:
+1. Use the [dotnet add reference](/dotnet/core/tools/dotnet-add-reference) command to add project reference between the **.AppHost** and **.WorkerService** project:
 
     ```dotnetcli
     dotnet add AspireStorage.AppHost/AspireStorage.AppHost.csproj reference AspireStorage.WorkerService/AspireStorage.WorkerService.csproj


### PR DESCRIPTION
Change command link from add package to add reference to match example

## Summary

The code example uses `dotnet add <project> reference <project>` but the link to the docs for the command points to the "dotnet add package" command.

The code example is correct and the link is incorrect. This updates the link.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/storage/azure-storage-components.md](https://github.com/dotnet/docs-aspire/blob/877a29690163bc355d838b30e868e011fc614bd4/docs/storage/azure-storage-components.md) | [Tutorial: Connect an ASP.NET Core app to .NET Aspire storage components](https://review.learn.microsoft.com/en-us/dotnet/aspire/storage/azure-storage-components?branch=pr-en-us-701) |

<!-- PREVIEW-TABLE-END -->