### PR TITLE
Fix the env var format for service endpoints

### DIFF
--- a/docs/fundamentals/app-host-overview.md
+++ b/docs/fundamentals/app-host-overview.md
@@ -122,7 +122,7 @@ The `port` parameter is the port that the container is listening on. For more in
 
 ### Service endpoint environment variable format
 
-In the preceding section, the `WithReference` method is used to express dependencies between resources. When service endpoints result in environment variables being injected into the dependent resource, the format may not be obvious. The following section provides details on this format.
+In the preceding section, the `WithReference` method is used to express dependencies between resources. When service endpoints result in environment variables being injected into the dependent resource, the format may not be obvious. This section provides details on this format.
 
 When one resource depends on another resource, the app host injects environment variables into the dependent resource. These environment variables configure the dependent resource to connect to the resource it depends on. The format of the environment variables is specific to .NET Aspire and expresses service endpoints in a way that is compatible with [Service Discovery](../service-discovery/overview.md).
 
@@ -134,7 +134,7 @@ Consider the following environment variable examples:
 services__apiservice__http__0
 ```
 
-The preceding environment variable expresses the first HTTP endpoint for the `apiservice` service. The value of the environment variable is the URL of the service endpoint. A named endpoint, might be expressed as follows:
+The preceding environment variable expresses the first HTTP endpoint for the `apiservice` service. The value of the environment variable is the URL of the service endpoint. A named endpoint might be expressed as follows:
 
 ```
 services__apiservice__myendpoint__0

--- a/docs/fundamentals/app-host-overview.md
+++ b/docs/fundamentals/app-host-overview.md
@@ -1,7 +1,7 @@
 ---
 title: .NET Aspire orchestration overview
 description: Learn the fundamental concepts of .NET Aspire orchestration and explore the various APIs to express resource references.
-ms.date: 04/10/2024
+ms.date: 04/22/2024
 ms.topic: overview
 ---
 
@@ -77,7 +77,7 @@ builder.AddProject<Projects.AspireApp_Web>("webfrontend")
        .WithReference(cache);
 ```
 
-The "webfrontend" project resource uses <xref:Aspire.Hosting.ResourceBuilderExtensions.WithReference%2A> to add a dependency on the "cache" container resource. These dependencies can represent connection strings or service discovery information. In the preceding example, an environment variable is injected into the "webfronend" resource with the name `ConnectionStrings__cache`. This environment variable contains a connection string that the webfrontend can use to connect to redis via the .NET Aspire Redis component, for example, `ConnectionStrings__cache="localhost:6379"`.
+The "webfrontend" project resource uses <xref:Aspire.Hosting.ResourceBuilderExtensions.WithReference%2A> to add a dependency on the "cache" container resource. These dependencies can represent connection strings or service discovery information. In the preceding example, an environment variable is injected into the "webfronend" resource with the name `ConnectionStrings__cache`. This environment variable contains a connection string that the webfrontend can use to connect to redis via the .NET Aspire Redis component, for example, `ConnectionStrings__cache="localhost:62354"`.
 
 ### Connection string and endpoint references
 
@@ -97,8 +97,8 @@ Project-to-project references are handled differently than resources that have w
 
 | Method | Environment variable |
 |--|--|
-| `WithReference(cache)` | `ConnectionStrings__cache="localhost:6379"` |
-| `WithReference(apiservice)` | `services__apiservice__0="http://_http.localhost:8034"` <br /> `services__apiservice__1="http://localhost:8034"` |
+| `WithReference(cache)` | `ConnectionStrings__cache="localhost:62354"` |
+| `WithReference(apiservice)` | `services__apiservice__http__0="http://localhost:5455"` <br /> `services__apiservice__https__0="https://localhost:7356"` |
 
 Adding a reference to the "apiservice" project results in service discovery environment variables being added to the front-end. This is because typically, project to project communication occurs over HTTP/gRPC. For more information, see [.NET Aspire service discovery](../service-discovery/overview.md).
 
@@ -106,7 +106,7 @@ It's possible to get specific endpoints from a container or executable using the
 
 ```csharp
 var customContainer = builder.AddContainer("myapp", "mycustomcontainer")
-                             .WithEndpoint(containerPort: 9043, name: "endpoint");
+                             .WithHttpEndpoint(port: 9043, name: "endpoint");
 
 var endpoint = customContainer.GetEndpoint("endpoint");
 
@@ -114,11 +114,33 @@ var apiservice = builder.AddProject<Projects.AspireApp_ApiService>("apiservice")
                         .WithReference(endpoint);
 ```
 
-| Method                    | Environment variable                            |
-|---------------------------|-------------------------------------------------|
-| `WithReference(endpoint)` | `services__myapp__0=endpoint://localhost:65256` |
+| Method                    | Environment variable                                  |
+|---------------------------|-------------------------------------------------------|
+| `WithReference(endpoint)` | `services__myapp__endpoint__0=https://localhost:9043` |
 
-The `containerPort` parameter is the port that the container is listening on. For more information on container ports, see [Container ports](networking-overview.md#container-ports). For more information on service discovery, see [.NET Aspire service discovery](../service-discovery/overview.md).
+The `port` parameter is the port that the container is listening on. For more information on container ports, see [Container ports](networking-overview.md#container-ports). For more information on service discovery, see [.NET Aspire service discovery](../service-discovery/overview.md).
+
+### Service endpoint environment variable format
+
+In the preceding section, the `WithReference` method is used to express dependencies between resources. When service endpoints result in environment variables being injected into the dependent resource, the format may not be obvious. The following section provides details on this format.
+
+When one resource depends on another resource, the app host injects environment variables into the dependent resource. These environment variables configure the dependent resource to connect to the resource it depends on. The format of the environment variables is specific to .NET Aspire and expresses service endpoints in a way that is compatible with [Service Discovery](../service-discovery/overview.md).
+
+Service endpoint environment variables start with `services` and are delimited by a double underscore `__`. They're prefixed with `services__`, followed by the service name, the service endpoint name or protocol, and the index. The index supports multiple endpoints for a single service, starting with `0` for the first endpoint and incrementing for each additional endpoint.
+
+Consider the following environment variable examples:
+
+```
+services__apiservice__http__0
+```
+
+The preceding environment variable expresses the first HTTP endpoint for the `apiservice` service. The value of the environment variable is the URL of the service endpoint. A named endpoint, might be expressed as follows:
+
+```
+services__apiservice__myendpoint__0
+```
+
+In the preceding example, the `apiservice` service has a named endpoint called `myendpoint`. The value of the environment variable is the URL of the service endpoint.
 
 ### APIs for adding and expressing resources
 

--- a/docs/fundamentals/networking-overview.md
+++ b/docs/fundamentals/networking-overview.md
@@ -1,7 +1,7 @@
 ---
 title: .NET Aspire inner loop networking overview
 description: Learn how .NET Aspire handles networking and service bindings, and how you can use them in your app code.
-ms.date: 03/07/2024
+ms.date: 04/22/2024
 ms.topic: overview
 ---
 
@@ -149,7 +149,7 @@ There's also an overload that allows you to specify a delegate to configure the 
 
 The preceding code provides a callback delegate to configure the endpoint. The endpoint is named `admin` and configured to use the `http` scheme and transport, as well as the 17003 host port. The consumer references this endpoint by name, consider the following `AddHttpClient` call:
 
-```
+```csharp
 builder.Services.AddHttpClient<WeatherApiClient>(
     client => client.BaseAddress = new Uri("http://_admin.apiservice"));
 ```

--- a/docs/get-started/build-aspire-apps-with-nodejs.md
+++ b/docs/get-started/build-aspire-apps-with-nodejs.md
@@ -123,7 +123,7 @@ There are several key modifications from the original Angular template. The firs
 
 :::code language="javascript" source="~/aspire-samples/samples/AspireWithJavaScript/AspireJavaScript.Angular/proxy.conf.js":::
 
-The preceding configuration proxies HTTP requests that start with `/api` to target the URL within the `services__weatherapi__1` environment variable. This environment variable is set by the .NET Aspire app host and is used to resolve the "weatherapi" service endpoint.
+The preceding configuration proxies HTTP requests that start with `/api` to target the URL within the `services__weatherapi__http__0` environment variable. This environment variable is set by the .NET Aspire app host and is used to resolve the "weatherapi" service endpoint.
 
 The second update is the to the _package.json_ file. This file is used to configure the Angular client to run on a different port than the default port. This is achieved by using the `PORT` environment variable, and the `run-script-os` npm package to set the port.
 
@@ -158,7 +158,7 @@ There are several key modifications from the original React template. The first 
 
 :::code language="ini" source="~/aspire-samples/samples/AspireWithJavaScript/AspireJavaScript.React/.env":::
 
-The preceding configuration sets the `REACT_APP_WEATHERAPI_URL` environment variable from the `services__weatherapi__1` environment variable. This environment variable is set by the .NET Aspire app host, and is used to resolve the "weatherapi" service endpoint.
+The preceding configuration sets the `REACT_APP_WEATHERAPI_URL` environment variable from the `services__weatherapi__http__0` environment variable. This environment variable is set by the .NET Aspire app host, and is used to resolve the "weatherapi" service endpoint.
 
 > [!IMPORTANT]
 > For custom environment variables to be available in the React client app, they must be prefixed with `REACT_APP_`. For more information, see [Adding custom environment variables](https://create-react-app.dev/docs/adding-custom-environment-variables/).
@@ -180,7 +180,7 @@ To visualize the React client app, navigate to the "react" endpoint in the .NET 
 
 ## Explore the Vue client
 
-There are several key modifications from the original Vue template. The first is the addition of an _.env_ file. This file configures a `VITE_WEATHERAPI_URL` environment variable from the `services__weatherapi__1` environment variable. This environment variable is set by the .NET Aspire app host and is used to resolve the "weatherapi" service endpoint.
+There are several key modifications from the original Vue template. The first is the addition of an _.env_ file. This file configures a `VITE_WEATHERAPI_URL` environment variable from the `services__weatherapi__http__0` environment variable. This environment variable is set by the .NET Aspire app host and is used to resolve the "weatherapi" service endpoint.
 
 :::code language="ini" source="~/aspire-samples/samples/AspireWithJavaScript/AspireJavaScript.Vue/.env":::
 


### PR DESCRIPTION
## Summary

Fix the env var format for service endpoints. /cc @ReubenBond 

Fixes #704


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/app-host-overview.md](https://github.com/dotnet/docs-aspire/blob/07182aae5fed72c9129a74372b7ee985d5fd5a6c/docs/fundamentals/app-host-overview.md) | [.NET Aspire orchestration overview](https://review.learn.microsoft.com/en-us/dotnet/aspire/fundamentals/app-host-overview?branch=pr-en-us-705) |
| [docs/fundamentals/networking-overview.md](https://github.com/dotnet/docs-aspire/blob/07182aae5fed72c9129a74372b7ee985d5fd5a6c/docs/fundamentals/networking-overview.md) | [.NET Aspire inner loop networking overview](https://review.learn.microsoft.com/en-us/dotnet/aspire/fundamentals/networking-overview?branch=pr-en-us-705) |
| [docs/get-started/build-aspire-apps-with-nodejs.md](https://github.com/dotnet/docs-aspire/blob/07182aae5fed72c9129a74372b7ee985d5fd5a6c/docs/get-started/build-aspire-apps-with-nodejs.md) | [Build .NET Aspire apps with Node.js](https://review.learn.microsoft.com/en-us/dotnet/aspire/get-started/build-aspire-apps-with-nodejs?branch=pr-en-us-705) |


<!-- PREVIEW-TABLE-END -->