### PR TITLE
nit: fixed spelling

### DIFF
--- a/docs/get-started/build-aspire-apps-with-nodejs.md
+++ b/docs/get-started/build-aspire-apps-with-nodejs.md
@@ -209,7 +209,7 @@ To visualize the Vue client app, navigate to the "vue" endpoint in the .NET Aspi
 
 ## Deployment considerations
 
-The sample source code for this article is designed to run locally. It has also been developed to deploy each client app as a container image. The _Dockerfile_ for each client app is used to build the container image. Each _Dockefile_ is identical, using a multistage build to create a production-ready container image.
+The sample source code for this article is designed to run locally. It has also been developed to deploy each client app as a container image. The _Dockerfile_ for each client app is used to build the container image. Each _Dockerfile_ is identical, using a multistage build to create a production-ready container image.
 
 :::code language="dockerfile" source="~/aspire-samples/samples/AspireWithJavaScript/AspireJavaScript.Angular/Dockerfile":::
 


### PR DESCRIPTION
## Summary

Fixed: Changed spelling from `Dockefile ` to `Dockerfile`


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/get-started/build-aspire-apps-with-nodejs.md](https://github.com/dotnet/docs-aspire/blob/09a7b8e9e0f7c39a00a8143781099c9ad960fd2f/docs/get-started/build-aspire-apps-with-nodejs.md) | [Build .NET Aspire apps with Node.js](https://review.learn.microsoft.com/en-us/dotnet/aspire/get-started/build-aspire-apps-with-nodejs?branch=pr-en-us-785) |

<!-- PREVIEW-TABLE-END -->