### PR TITLE
Fix ".NET" usage in Azure AI Search page

### DIFF
--- a/docs/azureai/azureai-search-document-component.md
+++ b/docs/azureai/azureai-search-document-component.md
@@ -1,11 +1,11 @@
 ---
-title: NET Aspire Azure AI Search Documents component
-description: Learn how to use the NET Aspire Azure AI Search Documents component.
+title: .NET Aspire Azure AI Search Documents component
+description: Learn how to use the .NET Aspire Azure AI Search Documents component.
 ms.topic: how-to
 ms.date: 04/18/2024
 ---
 
-# NET Aspire Azure AI Search Documents component
+# .NET Aspire Azure AI Search Documents component
 
 In this article, you learn how to use the .NET Aspire Azure AI Search Documents client. The `Aspire.Azure.Search.Documents` library is used to register an <xref:Azure.Search.Documents.Indexes.SearchIndexClient> in the dependency injection (DI) container for connecting to Azure Search. It enables corresponding health checks and logging.
 
@@ -16,7 +16,7 @@ For more information on using the `SearchIndexClient`, see [How to use Azure.Sea
 - Azure subscription: [create one for free](https://azure.microsoft.com/free/).
 - Azure Search service: [create an Azure OpenAI Service resource](/azure/search/search-create-service-portal).
 
-To get started with the NET Aspire Azure AI Search Documents component, install the [Aspire.Azure.Search.Documents](https://www.nuget.org/packages/Aspire.Azure.Search.Documents) NuGet package.
+To get started with the .NET Aspire Azure AI Search Documents component, install the [Aspire.Azure.Search.Documents](https://www.nuget.org/packages/Aspire.Azure.Search.Documents) NuGet package.
 
 ### [.NET CLI](#tab/dotnet-cli)
 
@@ -192,7 +192,7 @@ The .NET Aspire Azure AI Search Documents component implements a single health c
 
 ### Logging
 
-The NET Aspire Azure AI Search Documents component uses the following log categories:
+The .NET Aspire Azure AI Search Documents component uses the following log categories:
 
 - `Azure`
 - `Azure.Core`


### PR DESCRIPTION
Fixes #822

## Summary

Added the `.` to .NET

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/azureai/azureai-search-document-component.md](https://github.com/dotnet/docs-aspire/blob/aaa47ddcfa533056fe2c1c2a0a0c08c61f259086/docs/azureai/azureai-search-document-component.md) | [.NET Aspire Azure AI Search Documents component](https://review.learn.microsoft.com/en-us/dotnet/aspire/azureai/azureai-search-document-component?branch=pr-en-us-824) |

<!-- PREVIEW-TABLE-END -->