### PR TITLE
Update code samples to reflect API changes in preview-7

### DIFF
--- a/docs/azureai/azureai-openai-component.md
+++ b/docs/azureai/azureai-openai-component.md
@@ -140,7 +140,7 @@ The .NET Aspire Azure AI OpenAI component supports <xref:Microsoft.Extensions.Co
     "Azure": {
       "AI": {
         "OpenAI": {
-          "Tracing": true,
+          "DisableTracing": false,
         }
       }
     }
@@ -150,12 +150,12 @@ The .NET Aspire Azure AI OpenAI component supports <xref:Microsoft.Extensions.Co
 
 ### Use inline delegates
 
-Also you can pass the `Action<AzureOpenAISettings> configureSettings` delegate to set up some or all the options inline, for example to disable health checks from code:
+Also you can pass the `Action<AzureOpenAISettings> configureSettings` delegate to set up some or all the options inline, for example to disable tracing from code:
 
 ```csharp
 builder.AddAzureAIOpenAI(
     "openAiConnectionName",
-    static settings => settings.Tracing = false);
+    static settings => settings.DisableTracing = true);
 ```
 
 You can also setup the OpenAIClientOptions using the optional `Action<IAzureClientBuilder<OpenAIClient, OpenAIClientOptions>> configureClientBuilder` parameter of the `AddAzureAIOpenAI` method. For example, to set the client ID for this client:

--- a/docs/azureai/azureai-search-document-component.md
+++ b/docs/azureai/azureai-search-document-component.md
@@ -157,7 +157,7 @@ The .NET Aspire Azure AI Search library supports <xref:Microsoft.Extensions.Conf
     "Azure": {
       "Search": {
         "Documents": {
-          "Tracing": true,
+          "DisableTracing": false,
         }
       }
     }
@@ -172,7 +172,7 @@ You can also pass the `Action<AzureSearchSettings> configureSettings` delegate t
 ```csharp
 builder.AddAzureSearch(
     "searchConnectionName",
-    static settings => settings.Tracing = false);
+    static settings => settings.DisableTracing = true);
 ```
 
 You can also setup the <xref:Azure.Search.Documents.SearchClientOptions> using the optional `Action<IAzureClientBuilder<SearchIndexClient, SearchClientOptions>> configureClientBuilder` parameter of the `AddAzureSearch` method. For example, to set the client ID for this client:

--- a/docs/caching/stackexchange-redis-component.md
+++ b/docs/caching/stackexchange-redis-component.md
@@ -103,8 +103,8 @@ The .NET Aspire StackExchange Redis component supports <xref:Microsoft.Extension
           "ConnectTimeout": 3000,
           "ConnectRetry": 2
         },
-        "HealthChecks": false,
-        "Tracing": true
+        "DisableHealthChecks": true,
+        "DisableTracing": false
       }
     }
   }
@@ -113,12 +113,12 @@ The .NET Aspire StackExchange Redis component supports <xref:Microsoft.Extension
 
 ### Use inline delegates
 
-You can also pass the `Action<StackExchangeRedisSettings>` delegate to set up some or all the options inline, for example to configure `Tracing`:
+You can also pass the `Action<StackExchangeRedisSettings>` delegate to set up some or all the options inline, for example to configure `DisableTracing`:
 
 ```csharp
 builder.AddRedis(
     "cache",
-    settings => settings.Tracing = false);
+    settings => settings.DisableTracing = true);
 ```
 
 [!INCLUDE [component-health-checks](../includes/component-health-checks.md)]

--- a/docs/caching/stackexchange-redis-distributed-caching-component.md
+++ b/docs/caching/stackexchange-redis-distributed-caching-component.md
@@ -103,8 +103,8 @@ The .NET Aspire StackExchange Redis distributed caching component supports <xref
           "ConnectTimeout": 3000,
           "ConnectRetry": 2
         },
-        "HealthChecks": false,
-        "Tracing": true
+        "DisableHealthChecks": true,
+        "DisableTracing": false
       }
     }
   }
@@ -113,12 +113,12 @@ The .NET Aspire StackExchange Redis distributed caching component supports <xref
 
 ### Use inline delegates
 
-You can also pass the `Action<StackExchangeRedisSettings>` delegate to set up some or all the options inline, for example to configure `Tracing`:
+You can also pass the `Action<StackExchangeRedisSettings>` delegate to set up some or all the options inline, for example to configure `DisableTracing`:
 
 ```csharp
 builder.AddRedisDistributedCache(
     "cache",
-    settings => settings.Tracing = false);
+    settings => settings.DisableTracing = true);
 ```
 
 You can also set up the [ConfigurationOptions](https://stackexchange.github.io/StackExchange.Redis/Configuration.html#configuration-options) using the `Action<ConfigurationOptions> configureOptions` delegate parameter of the `AddRedisDistributedCache` method. For example to set the connection timeout:

--- a/docs/caching/stackexchange-redis-output-caching-component.md
+++ b/docs/caching/stackexchange-redis-output-caching-component.md
@@ -110,8 +110,8 @@ The .NET Aspire StackExchange Redis output caching component supports <xref:Micr
           "ConnectTimeout": 3000,
           "ConnectRetry": 2
         },
-        "HealthChecks": false,
-        "Tracing": true
+        "DisableHealthChecks": true,
+        "DisableTracing": false
       }
     }
   }
@@ -125,7 +125,7 @@ You can also pass the `Action<StackExchangeRedisSettings> configurationSettings`
 ```csharp
 builder.AddRedisOutputCache(
     "cache",
-    static settings => settings.HealthChecks = false);
+    static settings => settings.DisableHealthChecks  = true);
 ```
 
 You can also set up the [ConfigurationOptions](https://stackexchange.github.io/StackExchange.Redis/Configuration.html#configuration-options) using the `Action<ConfigurationOptions> configureOptions` delegate parameter of the <xref:Microsoft.Extensions.Hosting.AspireRedisOutputCacheExtensions.AddRedisOutputCache%2A> method. For example to set the connection timeout:

--- a/docs/database/azure-cosmos-db-component.md
+++ b/docs/database/azure-cosmos-db-component.md
@@ -139,7 +139,7 @@ The .NET Aspire Azure Cosmos DB component supports <xref:Microsoft.Extensions.Co
     "Microsoft": {
       "Azure": {
         "Cosmos": {
-          "Tracing": true,
+          "DisableTracing": false,
         }
       }
     }
@@ -154,7 +154,7 @@ You can also pass the `Action<AzureCosmosDBSettings>` delegate to set up some or
 ```csharp
 builder.AddAzureCosmosDB(
     "cosmosConnectionName",
-    static settings => settings.Tracing = false);
+    static settings => settings.DisableTracing = true);
 ```
 
 You can also set up the <xref:Microsoft.Azure.Cosmos.CosmosClientOptions?displayProperty=fullName> using the optional `Action<CosmosClientOptions> configureClientOptions` parameter of the `AddAzureCosmosDB` method. For example to set the <xref:Microsoft.Azure.Cosmos.CosmosClientOptions.ApplicationName?displayProperty=nameWithType> user-agent header suffix for all requests issues by this client:

--- a/docs/database/azure-cosmos-db-entity-framework-component.md
+++ b/docs/database/azure-cosmos-db-entity-framework-component.md
@@ -121,7 +121,7 @@ The .NET Aspire Microsoft Entity Framework Core Cosmos DB component supports <xr
       "EntityFrameworkCore": {
         "Cosmos": {
           "DbContextPooling": true,
-          "Tracing": false
+          "DisableTracing": true
         }
       }
     }
@@ -136,7 +136,7 @@ You can also pass the `Action<EntityFrameworkCoreCosmosDBSettings> configureSett
 ```csharp
 builder.AddCosmosDbContext<MyDbContext>(
     "cosmosdb",
-    settings => settings.Tracing = false);
+    settings => settings.DisableTracing = true);
 ```
 
 [!INCLUDE [component-health-checks](../includes/component-health-checks.md)]

--- a/docs/database/mongodb-component.md
+++ b/docs/database/mongodb-component.md
@@ -111,9 +111,9 @@ The following example shows an _appsettings.json_ file that configures some of t
     "MongoDB": {
       "Driver": {
         "ConnectionString": "mongodb://server:port/test",
-        "HealthChecks": true,
+        "DisableHealthChecks": false,
         "HealthCheckTimeout": 10000,
-        "Tracing": true
+        "DisableTracing": false
       },
     }
   }
@@ -133,12 +133,12 @@ builder.AddMongoDBClient("mongodb",
 
 Here are the configurable options with corresponding default values:
 
-| Name                 | Description                                                                         |
-|----------------------|-------------------------------------------------------------------------------------|
-| `ConnectionString`   | The connection string of the MongoDB database database to connect to.               |
-| `HealthChecks`       | A boolean value that indicates whether the database health check is enabled or not. |
-| `HealthCheckTimeout` | An `int?` value that indicates the MongoDB health check timeout in milliseconds.    |
-| `Tracing`            | A boolean value that indicates whether the OpenTelemetry tracing is enabled or not. |
+| Name                  | Description                                                                           |
+|-----------------------|---------------------------------------------------------------------------------------|
+| `ConnectionString`    | The connection string of the MongoDB database database to connect to.                 |
+| `DisableHealthChecks` | A boolean value that indicates whether the database health check is disabled or not.  |
+| `HealthCheckTimeout`  | An `int?` value that indicates the MongoDB health check timeout in milliseconds.      |
+| `DisableTracing`      | A boolean value that indicates whether the OpenTelemetry tracing is disabled or not.  |
 
 [!INCLUDE [component-health-checks](../includes/component-health-checks.md)]
 

--- a/docs/database/mysql-component.md
+++ b/docs/database/mysql-component.md
@@ -109,8 +109,8 @@ The following example shows an _appsettings.json_ file that configures some of t
 {
   "Aspire": {
     "MySqlConnector": {
-      "HealthChecks": false,
-      "Tracing": false
+      "DisableHealthChecks": true,
+      "DisableTracing": true
     }
   }
 }
@@ -122,19 +122,19 @@ You can also pass the `Action<MySqlConnectorSettings>` delegate to set up some o
 
 ```csharp
 builder.AddMySqlDataSource("mysql",
-    static settings => settings.HealthChecks = false);
+    static settings => settings.DisableHealthChecks  = true);
 ```
 
 ### Configuration options
 
 Here are the configurable options with corresponding default values:
 
-| Name               | Description                                                                          |
-|--------------------|--------------------------------------------------------------------------------------|
-| `ConnectionString` | The connection string of the MySQL database database to connect to.                  |
-| `HealthChecks`     | A boolean value that indicates whether the database health check is enabled or not.  |
-| `Tracing`          | A boolean value that indicates whether the OpenTelemetry tracing is enabled or not.  |
-| `Metrics`          | A boolean value that indicates whether the OpenTelemetry metrics are enabled or not. |
+| Name                  | Description                                                                           |
+|-----------------------|---------------------------------------------------------------------------------------|
+| `ConnectionString`    | The connection string of the MySQL database database to connect to.                   |
+| `DisableHealthChecks` | A boolean value that indicates whether the database health check is disabled or not.  |
+| `DisableTracing`      | A boolean value that indicates whether the OpenTelemetry tracing is disabled or not.  |
+| `DisableMetrics`      | A boolean value that indicates whether the OpenTelemetry metrics are disabled or not. |
 
 [!INCLUDE [component-health-checks](../includes/component-health-checks.md)]
 

--- a/docs/database/mysql-entity-framework-component.md
+++ b/docs/database/mysql-entity-framework-component.md
@@ -112,8 +112,8 @@ The following example shows an _appsettings.json_ that configures some of the av
     "Pomelo": {
       "EntityFrameworkCore": {
         "MySql": {
-          "HealthChecks": false,
-          "Tracing": false
+          "DisableHealthChecks": true,
+          "DisableTracing": true
         }
       }
     }
@@ -128,19 +128,19 @@ You can also pass the `Action<PomeloEntityFrameworkCoreMySqlSettings> configureS
 ```csharp
 builder.AddMySqlDbContext<MyDbContext>(
     "mysqldb1",
-    static settings => settings.HealthChecks = false);
+    static settings => settings.DisableHealthChecks  = true);
 ```
 
 or
 
 ```csharp
 builder.EnrichMySqlDbContext<MyDbContext>(
-    static settings => settings.HealthChecks = false);
+    static settings => settings.DisableHealthChecks  = true);
 ```
 
 [!INCLUDE [component-health-checks](../includes/component-health-checks.md)]
 
-The The .NET Aspire Pomelo MySQL Entity Framework Core component registers a basic health check that checks the database connection given a `TContext`. The health check is enabled by default and can be disabled using the `HealthChecks` property in the configuration.
+The The .NET Aspire Pomelo MySQL Entity Framework Core component registers a basic health check that checks the database connection given a `TContext`. The health check is enabled by default and can be disabled using the `DisableHealthChecks` property in the configuration.
 
 [!INCLUDE [component-observability-and-telemetry](../includes/component-observability-and-telemetry.md)]
 

--- a/docs/database/oracle-entity-framework-component.md
+++ b/docs/database/oracle-entity-framework-component.md
@@ -103,7 +103,7 @@ See the [ODP.NET documentation](https://www.oracle.com/database/technologies/app
 
 ### Use configuration providers
 
-The .NET Aspire Oracle Entity Framework Core component supports [Microsoft.Extensions.Configuration](https://learn.microsoft.com/dotnet/api/microsoft.extensions.configuration). It loads the `OracleEntityFrameworkCoreSettings` from configuration by using the `Aspire:Oracle:EntityFrameworkCore` key.
+The .NET Aspire Oracle Entity Framework Core component supports [Microsoft.Extensions.Configuration](/dotnet/api/microsoft.extensions.configuration). It loads the `OracleEntityFrameworkCoreSettings` from configuration by using the `Aspire:Oracle:EntityFrameworkCore` key.
 
 The following example shows an _appsettings.json_ that configures some of the available options:
 
@@ -112,10 +112,10 @@ The following example shows an _appsettings.json_ that configures some of the av
   "Aspire": {
     "Oracle": {
       "EntityFrameworkCore": {
-        "HealthChecks": false,
-        "Tracing": false,
-        "Metrics": true,
-        "Retry": true,
+        "DisableHealthChecks": true,
+        "DisableTracing": true,
+        "DisableMetrics": false,
+        "DisableRetry": false,
         "Timeout": 30
       }
     }
@@ -133,19 +133,19 @@ You can also pass the `Action<OracleEntityFrameworkCoreSettings> configureSettin
 ```csharp
 builder.AddOracleDatabaseDbContext<MyDbContext>(
     "oracle",
-    static settings => settings.HealthChecks = false);
+    static settings => settings.DisableHealthChecks  = true);
 ```
 
 or
 
 ```csharp
 builder.EnrichOracleDatabaseDbContext<MyDbContext>(
-    static settings => settings.HealthChecks = false);
+    static settings => settings.DisableHealthChecks  = true);
 ```
 
 [!INCLUDE [component-health-checks](../includes/component-health-checks.md)]
 
-The The .NET Aspire Oracle Entity Framework Core component registers a basic health check that checks the database connection given a `TContext`. The health check is enabled by default and can be disabled using the `HealthChecks` property in the configuration.
+The The .NET Aspire Oracle Entity Framework Core component registers a basic health check that checks the database connection given a `TContext`. The health check is enabled by default and can be disabled using the `DisableHealthChecks` property in the configuration.
 
 [!INCLUDE [component-observability-and-telemetry](../includes/component-observability-and-telemetry.md)]
 

--- a/docs/database/postgresql-component.md
+++ b/docs/database/postgresql-component.md
@@ -96,8 +96,8 @@ The following example shows an _appsettings.json_ file that configures some of t
 {
   "Aspire": {
     "Npgsql": {
-      "HealthChecks": false,
-      "Tracing": false
+      "DisableHealthChecks": true,
+      "DisableTracing": true
     }
   }
 }
@@ -105,12 +105,12 @@ The following example shows an _appsettings.json_ file that configures some of t
 
 ### Use inline delegates
 
-You can also pass the `Action<NpgsqlSettings> configureSettings` delegate to set up some or all the options inline, for example to set the `ConnectionString`:
+You can also pass the `Action<NpgsqlSettings> configureSettings` delegate to set up some or all the options inline, for example to disable health checks:
 
 ```csharp
 builder.AddNpgsqlDataSource(
     "postgresdb",
-     settings => settings.HealthChecks = false);
+     settings => settings.DisableHealthChecks  = true);
 ```
 
 [!INCLUDE [component-health-checks](../includes/component-health-checks.md)]

--- a/docs/database/postgresql-entity-framework-component.md
+++ b/docs/database/postgresql-entity-framework-component.md
@@ -90,8 +90,8 @@ The following example shows an _appsettings.json_ file that configures some of t
         "PostgreSQL": {
           "ConnectionString": "YOUR_CONNECTIONSTRING",
           "DbContextPooling": true,
-          "HealthChecks": false,
-          "Tracing": false
+          "DisableHealthChecks": true,
+          "DisableTracing": true
         }
       }
     }
@@ -121,11 +121,11 @@ If you want to register more than one <xref:Microsoft.EntityFrameworkCore.DbCont
         "PostgreSQL": {
           "ConnectionString": "YOUR_CONNECTIONSTRING",
           "DbContextPooling": true,
-          "HealthChecks": false,
-          "Tracing": false,
+          "DisableHealthChecks": true,
+          "DisableTracing": true,
           "AnotherDbContext": {
             "ConnectionString": "AnotherDbContext_CONNECTIONSTRING",
-            "Tracing": true
+            "DisableTracing": false
           }
         }
       }
@@ -144,13 +144,13 @@ builder.AddNpgsqlDbContext<AnotherDbContext>();
 
 Here are the configurable options with corresponding default values:
 
-| Name               | Description                                                                                           |
-|--------------------|-------------------------------------------------------------------------------------------------------|
-| `ConnectionString` | The connection string of the SQL Server database to connect to.                                       |
-| `MaxRetryCount`    | The maximum number of retry attempts. Default value is 6, set it to 0 to disable the retry mechanism. |
-| `HealthChecks`     | A boolean value that indicates whether the database health check is enabled or not.                   |
-| `Tracing`          | A boolean value that indicates whether the OpenTelemetry tracing is enabled or not.                   |
-| `Metrics`          | A boolean value that indicates whether the OpenTelemetry metrics are enabled or not.                  |
+| Name                  | Description                                                                                            |
+|-----------------------|--------------------------------------------------------------------------------------------------------|
+| `ConnectionString`    | The connection string of the SQL Server database to connect to.                                        |
+| `MaxRetryCount`       | The maximum number of retry attempts. Default value is 6, set it to 0 to disable the retry mechanism.  |
+| `DisableHealthChecks` | A boolean value that indicates whether the database health check is disabled or not.                   |
+| `DisableTracing`      | A boolean value that indicates whether the OpenTelemetry tracing is disabled or not.                   |
+| `DisableMetrics`      | A boolean value that indicates whether the OpenTelemetry metrics are disabled or not.                  |
 
 [!INCLUDE [component-health-checks](../includes/component-health-checks.md)]
 

--- a/docs/database/sql-server-component.md
+++ b/docs/database/sql-server-component.md
@@ -93,8 +93,8 @@ The following example shows an _appsettings.json_ file that configures some of t
     "SqlServer": {
       "SqlClient": {
         "ConnectionString": "YOUR_CONNECTIONSTRING",
-        "HealthChecks": true,
-        "Metrics": false
+        "DisableHealthChecks": false,
+        "DisableMetrics": true
       }
     }
   }
@@ -103,11 +103,11 @@ The following example shows an _appsettings.json_ file that configures some of t
 
 ### Use inline configurations
 
-You can also pass the `Action<MicrosoftDataSqlClientSettings>` delegate to set up some or all the options inline, for example to turn off the `Metrics`:
+You can also pass the `Action<MicrosoftDataSqlClientSettings>` delegate to set up some or all the options inline, for example to turn off the `DisableMetrics`:
 
 ```csharp
 builder.AddSqlServerSqlClientConfig(
-    static settings => settings.Metrics = false);
+    static settings => settings.DisableMetrics = true);
 ```
 
 ### Configuring connections to multiple databases
@@ -121,7 +121,7 @@ If you want to add more than one `SqlConnection` you could use named instances. 
       "SqlClient": {
         "INSTANCE_NAME": {
           "ServiceUri": "YOUR_URI",
-          "HealthChecks": false
+          "DisableHealthChecks": true
         }
       }
     }
@@ -139,12 +139,12 @@ builder.AddSqlServerSqlClientConfig("INSTANCE_NAME");
 
 Here are the configurable options with corresponding default values:
 
-| Name               | Description                                                                          |
-|--------------------|--------------------------------------------------------------------------------------|
-| `ConnectionString` | The connection string of the SQL Server database to connect to.                      |
-| `HealthChecks`     | A boolean value that indicates whether the database health check is enabled or not.  |
-| `Tracing`          | A boolean value that indicates whether the OpenTelemetry tracing is enabled or not.  |
-| `Metrics`          | A boolean value that indicates whether the OpenTelemetry metrics are enabled or not. |
+| Name                  | Description                                                                           |
+|-----------------------|---------------------------------------------------------------------------------------|
+| `ConnectionString`    | The connection string of the SQL Server database to connect to.                       |
+| `DisableHealthChecks` | A boolean value that indicates whether the database health check is disabled or not.  |
+| `DisableTracing`      | A boolean value that indicates whether the OpenTelemetry tracing is disabled or not.  |
+| `DisableMetrics`      | A boolean value that indicates whether the OpenTelemetry metrics are disabled or not. |
 
 [!INCLUDE [component-health-checks](../includes/component-health-checks.md)]
 

--- a/docs/database/sql-server-entity-framework-component.md
+++ b/docs/database/sql-server-entity-framework-component.md
@@ -92,9 +92,9 @@ The following is an example of an _appsettings.json_ file that configures some o
         "SqlServer": {
           "ConnectionString": "YOUR_CONNECTIONSTRING",
           "DbContextPooling": true,
-          "HealthChecks": false,
-          "Tracing": false,
-          "Metrics": true
+          "DisableHealthChecks": true,
+          "DisableTracing": true,
+          "DisableMetrics": false
         }
       }
     }
@@ -104,13 +104,13 @@ The following is an example of an _appsettings.json_ file that configures some o
 
 ### Use inline configurations
 
-You can also pass the `Action<MicrosoftEntityFrameworkCoreSqlServerSettings>` delegate to set up some or all the options inline, for example to turn off the `Metrics`:
+You can also pass the `Action<MicrosoftEntityFrameworkCoreSqlServerSettings>` delegate to set up some or all the options inline, for example to turn off the metrics:
 
 ```csharp
 builder.AddSqlServerDbContext<YourDbContext>(
     "sql",
     static settings =>
-        settings.ConnectionString = "YOUR_CONNECTIONSTRING");
+        settings.DisableMetrics = true);
 ```
 
 ### Configure multiple DbContext connections
@@ -125,12 +125,12 @@ If you want to register more than one `DbContext` with different configuration, 
           "SqlServer": {
             "ConnectionString": "YOUR_CONNECTIONSTRING",
             "DbContextPooling": true,
-            "HealthChecks": false,
-            "Tracing": false,
-            "Metrics": true,
+            "DisableHealthChecks": true,
+            "DisableTracing": true,
+            "DisableMetrics": false,
           "AnotherDbContext": {
             "ConnectionString": "AnotherDbContext_CONNECTIONSTRING",
-            "Tracing": true
+            "DisableTracing": false
           }
         }
       }
@@ -149,15 +149,15 @@ builder.AddSqlServerDbContext<AnotherDbContext>("another-sql");
 
 Here are the configurable options with corresponding default values:
 
-| Name | Description |
-|--|--|
-| `ConnectionString` | The connection string of the SQL Server database to connect to. |
-| `DbContextPooling` | A boolean value that indicates whether the db context will be pooled or explicitly created every time it's requested |
-| `MaxRetryCount` | The maximum number of retry attempts. Default value is 6, set it to 0 to disable the retry mechanism. |
-| `HealthChecks` | A boolean value that indicates whether the database health check is enabled or not. |
-| `Tracing` | A boolean value that indicates whether the OpenTelemetry tracing is enabled or not. |
-| `Metrics` | A boolean value that indicates whether the OpenTelemetry metrics are enabled or not. |
-| `Timeout` | The time in seconds to wait for the command to execute. |
+| Name                  | Description                                                                                                          |
+|-----------------------|----------------------------------------------------------------------------------------------------------------------|
+| `ConnectionString`    | The connection string of the SQL Server database to connect to.                                                      |
+| `DbContextPooling`    | A boolean value that indicates whether the db context will be pooled or explicitly created every time it's requested |
+| `MaxRetryCount`       | The maximum number of retry attempts. Default value is 6, set it to 0 to disable the retry mechanism.                |
+| `DisableHealthChecks` | A boolean value that indicates whether the database health check is disabled or not.                                 |
+| `DisableTracing`      | A boolean value that indicates whether the OpenTelemetry tracing is disabled or not.                                 |
+| `DisableMetrics`      | A boolean value that indicates whether the OpenTelemetry metrics are disabled or not.                                |
+| `Timeout`             | The time in seconds to wait for the command to execute.                                                              |
 
 [!INCLUDE [component-health-checks](../includes/component-health-checks.md)]
 

--- a/docs/fundamentals/components-overview.md
+++ b/docs/fundamentals/components-overview.md
@@ -103,8 +103,8 @@ For example, add the following code to the _appsettings.json_ file to configure 
 {
   "Aspire": {
     "Npgsql": {
-      "HealthChecks": false,
-      "Tracing": false
+      "DisableHealthChecks": true,
+      "DisableTracing": true
     }
   }
 }
@@ -115,7 +115,7 @@ Alternatively, you can configure the component directly in your code using a del
 ```csharp
 builder.AddNpgsqlDataSource(
     "PostgreSqlConnection",
-    static settings => settings.HealthChecks = false);
+    static settings => settings.DisableHealthChecks  = true);
 ```
 
 ## Dependency injection
@@ -137,7 +137,7 @@ For more information, see [.NET dependency injection](/dotnet/core/extensions/de
 ```csharp
 builder.AddKeyedNpgsqlDataSource(
     "PostgreSqlConnection",
-    static settings => settings.HealthChecks = false);
+    static settings => settings.DisableHealthChecks  = true);
 ```
 
 You can then retrieve the registered service using the <xref:Microsoft.Extensions.DependencyInjection.FromKeyedServicesAttribute>:

--- a/docs/fundamentals/health-checks.md
+++ b/docs/fundamentals/health-checks.md
@@ -74,7 +74,7 @@ You can disable health checks for a given component using one of the available c
 {
   "Aspire": {
     "Npgsql": {
-      "HealthChecks": false,
+      "DisableHealthChecks": true,
     }
   }
 }
@@ -85,7 +85,7 @@ You can also use an inline delegate to configure health checks:
 ```csharp
 builder.AddNpgsqlDbContext<MyDbContext>(
     "postgresdb",
-    static settings => settings.HealthChecks = false);
+    static settings => settings.DisableHealthChecks  = true);
 ```
 
 ## See also

--- a/docs/logging/seq-component.md
+++ b/docs/logging/seq-component.md
@@ -52,7 +52,7 @@ The .NET Aspire Seq component supports <xref:Microsoft.Extensions.Configuration?
 {
   "Aspire": {
     "Seq": {
-      "HealthChecks": false,
+      "DisableHealthChecks": true,
       "ServerUrl": "http://localhost:5341"
     }
   }
@@ -66,7 +66,7 @@ You can pass the `Action<SeqSettings> configureSettings` delegate to set up some
 ```csharp
 builder.AddSeqEndpoint("seq", static settings => 
 {
-    settings.HealthChecks = false;
+    settings.DisableHealthChecks  = true;
     settings.ServerUrl = "http://localhost:5341"
 });
 ```

--- a/docs/messaging/azure-event-hubs-component.md
+++ b/docs/messaging/azure-event-hubs-component.md
@@ -114,7 +114,7 @@ builder.AddAzureEventProcessorClient(
 
 ## Configuration
 
-The .NET Aspire Azure Event Hubs library provides multiple options to configure the Azure Event Hubs connection based on the requirements and conventions of your project. Either a `Namespace` or a `ConnectionString` is a required to be supplied.
+The .NET Aspire Azure Event Hubs library provides multiple options to configure the Azure Event Hubs connection based on the requirements and conventions of your project. Either a `FullyQualifiedNamespace` or a `ConnectionString` is a required to be supplied.
 
 ### Use a connection string
 

--- a/docs/messaging/azure-service-bus-component.md
+++ b/docs/messaging/azure-service-bus-component.md
@@ -101,8 +101,8 @@ The Service Bus component supports <xref:Microsoft.Extensions.Configuration?disp
     "Azure": {
       "Messaging": {
         "ServiceBus": {
-          "HealthChecks": false,
-          "Tracing": true,
+          "DisableHealthChecks": true,
+          "DisableTracing": false,
           "ClientOptions": {
             "Identifier": "CLIENT_ID"
           }
@@ -117,12 +117,12 @@ If you have set up your configurations in the `Aspire:Azure:Messaging:ServiceBus
 
 ### Use inline delegates
 
-You can also pass the `Action<AzureMessagingServiceBusSettings>` delegate to set up some or all the options inline, for example to set the `Namespace`:
+You can also pass the `Action<AzureMessagingServiceBusSettings>` delegate to set up some or all the options inline, for example to set the `FullyQualifiedNamespace`:
 
 ```csharp
 builder.AddAzureServiceBus(
     "messaging",
-    static settings => settings.Namespace = "YOUR_SERVICE_BUS_NAMESPACE");
+    static settings => settings.FullyQualifiedNamespace = "YOUR_SERVICE_BUS_NAMESPACE");
 ```
 
 You can also set up the [ServiceBusClientOptions](/dotnet/api/azure.messaging.servicebus.servicebusclientoptions) using `Action<IAzureClientBuilder<ServiceBusClient, ServiceBusClientOptions>>` delegate, the second parameter of the `AddAzureServiceBus` method. For example to set the `ServiceBusClient` ID to identify the client:
@@ -151,7 +151,7 @@ The corresponding configuration JSON is defined as follows:
     "Azure": {
       "Messaging": {
         "INSTANCE_NAME": {
-          "Namespace": "YOUR_SERVICE_BUS_NAMESPACE",
+          "FullyQualifiedNamespace": "YOUR_SERVICE_BUS_NAMESPACE",
           "ClientOptions": {
             "Identifier": "CLIENT_ID"
           }
@@ -166,11 +166,11 @@ The corresponding configuration JSON is defined as follows:
 
 The following configurable options are exposed through the <xref:Aspire.Azure.Messaging.ServiceBus.AzureMessagingServiceBusSettings> class:
 
-| Name               | Description                                                         |
-|--------------------|---------------------------------------------------------------------|
-| `ConnectionString` | The connection string used to connect to the Service Bus namespace. |
-| `Credential`       | The credential used to authenticate to the Service Bus namespace.   |
-| `Namespace`        | The fully qualified Service Bus namespace.                          |
+| Name                      | Description                                                         |
+|---------------------------|---------------------------------------------------------------------|
+| `ConnectionString`        | The connection string used to connect to the Service Bus namespace. |
+| `Credential`              | The credential used to authenticate to the Service Bus namespace.   |
+| `FullyQualifiedNamespace` | The fully qualified Service Bus namespace.                          |
 
 [!INCLUDE [component-observability-and-telemetry](../includes/component-observability-and-telemetry.md)]
 

--- a/docs/messaging/kafka-component.md
+++ b/docs/messaging/kafka-component.md
@@ -104,7 +104,7 @@ The .NET Aspire Apache Kafka component supports <xref:Microsoft.Extensions.Confi
     "Confluent": {
       "Kafka": {
         "Producer": {
-          "HealthChecks": true,
+          "DisableHealthChecks": false,
           "Config": {
             "Acks": "All"
           }
@@ -126,13 +126,13 @@ The `Config` properties of both  `Aspire:Confluent:Kafka:Producer` and `Aspire.C
 You can pass the `Action<KafkaProducerSettings> configureSettings` delegate to set up some or all the options inline, for example to disable health checks from code:
 
 ```csharp
-builder.AddKafkaProducer<string, string>("messaging", settings => settings.HealthChecks = false);
+builder.AddKafkaProducer<string, string>("messaging", settings => settings.DisableHealthChecks  = true);
 ```
 
 You can configure inline a consumer from code:
 
 ```csharp
-builder.AddKafkaConsumer<string, string>("messaging", settings => settings.HealthChecks = false);
+builder.AddKafkaConsumer<string, string>("messaging", settings => settings.DisableHealthChecks  = true);
 ```
 
 #### Configuring `ProducerBuilder<TKey, TValue>` and `ConsumerBuilder<TKey, TValue>`

--- a/docs/messaging/nats-component.md
+++ b/docs/messaging/nats-component.md
@@ -87,7 +87,7 @@ The .NET Aspire NATS component supports [Microsoft.Extensions.Configuration](/do
   "Aspire": {
     "Nats": {
       "Client": {
-        "HealthChecks": false
+        "DisableHealthChecks": true
       }
     }
   }
@@ -99,7 +99,7 @@ The .NET Aspire NATS component supports [Microsoft.Extensions.Configuration](/do
 Pass the `Action<NatsClientSettings> configureSettings` delegate to set up some or all the options inline, for example to disable health checks from code:
 
 ```csharp
-builder.AddNatsClient("nats", settings => settings.HealthChecks = false);
+builder.AddNatsClient("nats", settings => settings.DisableHealthChecks  = true);
 ```
 
 ## AppHost extensions

--- a/docs/messaging/rabbitmq-client-component.md
+++ b/docs/messaging/rabbitmq-client-component.md
@@ -95,7 +95,7 @@ The .NET Aspire RabbitMQ component supports <xref:Microsoft.Extensions.Configura
   "Aspire": {
     "RabbitMQ": {
       "Client": {
-        "HealthChecks": false
+        "DisableHealthChecks": true
       }
     }
   }
@@ -109,7 +109,7 @@ Also you can pass the `Action<RabbitMQClientSettings> configureSettings` delegat
 ```csharp
 builder.AddRabbitMQ(
     "messaging",
-    static settings => settings.HealthChecks = false);
+    static settings => settings.DisableHealthChecks  = true);
 ```
 
 You can also set up the [IConnectionFactory](https://rabbitmq.github.io/rabbitmq-dotnet-client/api/RabbitMQ.Client.IConnectionFactory.html) using the `Action<IConnectionFactory> configureConnectionFactory` delegate parameter of the `AddRabbitMQ` method. For example to set the client provided name for connections:

--- a/docs/security/azure-security-key-vault-component.md
+++ b/docs/security/azure-security-key-vault-component.md
@@ -94,8 +94,8 @@ The .NET Aspire Azure Key Vault component supports <xref:Microsoft.Extensions.Co
       "Security": {
         "KeyVault": {
           "VaultUri": "YOUR_VAULT_URI",
-          "HealthChecks": true,
-          "Tracing": false,
+          "DisableHealthChecks": false,
+          "DisableTracing": true,
           "ClientOptions": {
             "DisableChallengeResourceVerification": true
           }
@@ -110,12 +110,12 @@ If you have set up your configurations in the `Aspire:Azure:Security:KeyVault` s
 
 ### Use inline delegates
 
-You can also pass the `Action<AzureSecurityKeyVaultSettings>` delegate to set up some or all the options inline, for example to set the `Namespace`:
+You can also pass the `Action<AzureSecurityKeyVaultSettings>` delegate to set up some or all the options inline, for example to set the `VaultUri`:
 
 ```csharp
 builder.AddAzureKeyVaultSecrets(
     "secrets",
-    static settings => settings.ServiceUri = new Uri("YOUR_SERVICEURI"));
+    static settings => settings.VaultUri = new Uri("YOUR_VAULTURI"));
 ```
 
 You can also set up the <xref:Azure.Security.KeyVault.Secrets.SecretClientOptions> using `Action<IAzureClientBuilder<SecretClient, SecretClientOptions>>` delegate, the second parameter of the `AddAzureKeyVaultSecrets` method. For example to set the <xref:Azure.Security.KeyVault.Keys.KeyClientOptions.DisableChallengeResourceVerification?displayProperty=nameWithType> ID to identify the client:
@@ -146,8 +146,8 @@ The corresponding configuration JSON is defined as follows:
         "KeyVault": {
           "INSTANCE_NAME": {
             "VaultUri": "YOUR_VAULT_URI",
-            "HealthChecks": true,
-            "Tracing": false,
+            "DisableHealthChecks": false,
+            "DisableTracing": true,
             "ClientOptions": {
               "DisableChallengeResourceVerification": true
             }
@@ -163,12 +163,12 @@ The corresponding configuration JSON is defined as follows:
 
 The following configurable options are exposed through the <xref:Aspire.Azure.Security.KeyVault.AzureSecurityKeyVaultSettings> class:
 
-| Name           | Description                                                                                 |
-|----------------|---------------------------------------------------------------------------------------------|
-| `VaultUri`     | A URI to the vault on which the client operates. Appears as "DNS Name" in the Azure portal. |
-| `Credential`   | The credential used to authenticate to the Azure Key Vault.                                 |
-| `HealthChecks` | A boolean value that indicates whether the Key Vault health check is enabled or not.        |
-| `Tracing`      | A boolean value that indicates whether the OpenTelemetry tracing is enabled or not.         |
+| Name                  | Description                                                                                  |
+|-----------------------|----------------------------------------------------------------------------------------------|
+| `VaultUri`            | A URI to the vault on which the client operates. Appears as "DNS Name" in the Azure portal.  |
+| `Credential`          | The credential used to authenticate to the Azure Key Vault.                                  |
+| `DisableHealthChecks` | A boolean value that indicates whether the Key Vault health check is disabled or not.        |
+| `DisableTracing`      | A boolean value that indicates whether the OpenTelemetry tracing is disabled or not.         |
 
 [!INCLUDE [component-health-checks](../includes/component-health-checks.md)]
 

--- a/docs/storage/azure-storage-blobs-component.md
+++ b/docs/storage/azure-storage-blobs-component.md
@@ -130,8 +130,8 @@ The .NET Aspire Azure Blob Storage component supports <xref:Microsoft.Extensions
     "Azure": {
       "Storage": {
         "Blobs": {
-          "HealthChecks": false,
-          "Tracing": true,
+          "DisableHealthChecks": true,
+          "DisableTracing": false,
           "ClientOptions": {
             "Diagnostics": {
               "ApplicationId": "myapp"
@@ -151,7 +151,7 @@ You can also pass the `Action<AzureStorageBlobsSettings> configureSettings` dele
 ```csharp
 builder.AddAzureBlobClient(
     "blobs",
-    static settings => settings.HealthChecks = false);
+    static settings => settings.DisableHealthChecks  = true);
 ```
 
 You can also set up the `BlobClientOptions` using `Action<IAzureClientBuilder<BlobServiceClient, BlobClientOptions>> configureClientBuilder` delegate, the second parameter of the `AddAzureBlobClient` method. For example, to set the first part of user-agent headers for all requests issues by this client:

--- a/docs/storage/azure-storage-queues-component.md
+++ b/docs/storage/azure-storage-queues-component.md
@@ -130,8 +130,8 @@ The .NET Aspire Azure Queue Storage component supports <xref:Microsoft.Extension
     "Azure": {
       "Storage": {
         "Queues": {
-          "HealthChecks": false,
-          "Tracing": true,
+          "DisableHealthChecks": true,
+          "DisableTracing": false,
           "ClientOptions": {
             "Diagnostics": {
               "ApplicationId": "myapp"
@@ -146,12 +146,12 @@ The .NET Aspire Azure Queue Storage component supports <xref:Microsoft.Extension
 
 ### Use inline delegates
 
-You can also pass the `Action<AzureStorageQueuesSettings> configureSettings` delegate to set up some or all the options inline, for example to set the `Namespace`:
+You can also pass the `Action<AzureStorageQueuesSettings> configureSettings` delegate to set up some or all the options inline, for example to disable the health check:
 
 ```csharp
 builder.AddAzureQueueClient(
     "queue",
-    static settings => settings.HealthChecks = false);
+    static settings => settings.DisableHealthChecks  = true);
 ```
 
 You can also set up the `QueueClientOptions` using `Action<IAzureClientBuilder<QueueServiceClient, QueueClientOptions>> configureClientBuilder` delegate, the second parameter of the <xref:Microsoft.Extensions.Hosting.AspireQueueStorageExtensions.AddAzureQueueClient%2A> method. For example, to set the first part of user-agent headers for all requests issues by this client:

--- a/docs/storage/azure-storage-tables-component.md
+++ b/docs/storage/azure-storage-tables-component.md
@@ -103,8 +103,8 @@ The .NET Aspire Azure Table Storage component supports <xref:Microsoft.Extension
       "Data": {
         "Tables": {
           "ServiceUri": "YOUR_URI",
-          "HealthChecks": false,
-          "Tracing": true,
+          "DisableHealthChecks": true,
+          "DisableTracing": false,
           "ClientOptions": {
           "EnableTenantDiscovery": true
           }
@@ -119,7 +119,7 @@ If you have set up your configurations in the `Aspire:Azure:Data:Tables` section
 
 ### Use inline delegates
 
-You can also pass the `Action<AzureDataTablesSettings>` delegate to set up some or all the options inline, for example to set the `Namespace`:
+You can also pass the `Action<AzureDataTablesSettings>` delegate to set up some or all the options inline, for example to set the `ServiceUri`:
 
 ```csharp
 builder.AddAzureTableClient(
@@ -155,7 +155,7 @@ The corresponding configuration JSON is defined as follows:
         "Tables": {
           "INSTANCE_NAME": {
             "ServiceUri": "YOUR_URI",
-            "HealthChecks": false,
+            "DisableHealthChecks": true,
             "ClientOptions": {
               "EnableTenantDiscovery": true
             }
@@ -171,12 +171,12 @@ The corresponding configuration JSON is defined as follows:
 
 The following configurable options are exposed through the <xref:Aspire.Azure.Data.Tables.AzureDataTablesSettings> class:
 
-| Name           | Description                                                                              |
-|----------------|------------------------------------------------------------------------------------------|
-| `ServiceUri`   | A "Uri" referencing the Table service.                                                   |
-| `Credential`   | The credential used to authenticate to the Table Storage.                                |
-| `HealthChecks` | A boolean value that indicates whether the Table Storage health check is enabled or not. |
-| `Tracing`      | A boolean value that indicates whether the OpenTelemetry tracing is enabled or not.      |
+| Name                  | Description                                                                               |
+|-----------------------|-------------------------------------------------------------------------------------------|
+| `ServiceUri`          | A "Uri" referencing the Table service.                                                    |
+| `Credential`          | The credential used to authenticate to the Table Storage.                                 |
+| `DisableHealthChecks` | A boolean value that indicates whether the Table Storage health check is disabled or not. |
+| `DisableTracing`      | A boolean value that indicates whether the OpenTelemetry tracing is disabled or not.      |
 
 [!INCLUDE [component-health-checks](../includes/component-health-checks.md)]
 


### PR DESCRIPTION
- Fixes #842
- Fixes #853

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

<details><summary><strong>Toggle expand/collapse</strong></summary><br/>

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/azureai/azureai-openai-component.md](https://github.com/dotnet/docs-aspire/blob/3dd98d00f6295a9d036113d01962b8f4eb2d53a6/docs/azureai/azureai-openai-component.md) | [.NET Aspire Azure AI OpenAI component](https://review.learn.microsoft.com/en-us/dotnet/aspire/azureai/azureai-openai-component?branch=pr-en-us-846) |
| [docs/azureai/azureai-search-document-component.md](https://github.com/dotnet/docs-aspire/blob/3dd98d00f6295a9d036113d01962b8f4eb2d53a6/docs/azureai/azureai-search-document-component.md) | [NET Aspire Azure AI Search Documents component](https://review.learn.microsoft.com/en-us/dotnet/aspire/azureai/azureai-search-document-component?branch=pr-en-us-846) |
| [docs/caching/stackexchange-redis-component.md](https://github.com/dotnet/docs-aspire/blob/3dd98d00f6295a9d036113d01962b8f4eb2d53a6/docs/caching/stackexchange-redis-component.md) | [.NET Aspire StackExchange Redis component](https://review.learn.microsoft.com/en-us/dotnet/aspire/caching/stackexchange-redis-component?branch=pr-en-us-846) |
| [docs/caching/stackexchange-redis-distributed-caching-component.md](https://github.com/dotnet/docs-aspire/blob/3dd98d00f6295a9d036113d01962b8f4eb2d53a6/docs/caching/stackexchange-redis-distributed-caching-component.md) | [docs/caching/stackexchange-redis-distributed-caching-component](https://review.learn.microsoft.com/en-us/dotnet/aspire/caching/stackexchange-redis-distributed-caching-component?branch=pr-en-us-846) |
| [docs/caching/stackexchange-redis-output-caching-component.md](https://github.com/dotnet/docs-aspire/blob/3dd98d00f6295a9d036113d01962b8f4eb2d53a6/docs/caching/stackexchange-redis-output-caching-component.md) | [.NET Aspire StackExchange Redis output caching component](https://review.learn.microsoft.com/en-us/dotnet/aspire/caching/stackexchange-redis-output-caching-component?branch=pr-en-us-846) |
| [docs/database/azure-cosmos-db-component.md](https://github.com/dotnet/docs-aspire/blob/3dd98d00f6295a9d036113d01962b8f4eb2d53a6/docs/database/azure-cosmos-db-component.md) | [.NET Aspire Azure Cosmos DB component](https://review.learn.microsoft.com/en-us/dotnet/aspire/database/azure-cosmos-db-component?branch=pr-en-us-846) |
| [docs/database/azure-cosmos-db-entity-framework-component.md](https://github.com/dotnet/docs-aspire/blob/3dd98d00f6295a9d036113d01962b8f4eb2d53a6/docs/database/azure-cosmos-db-entity-framework-component.md) | [.NET Aspire Microsoft Entity Framework Core Cosmos DB component](https://review.learn.microsoft.com/en-us/dotnet/aspire/database/azure-cosmos-db-entity-framework-component?branch=pr-en-us-846) |
| [docs/database/mongodb-component.md](https://github.com/dotnet/docs-aspire/blob/3dd98d00f6295a9d036113d01962b8f4eb2d53a6/docs/database/mongodb-component.md) | [docs/database/mongodb-component](https://review.learn.microsoft.com/en-us/dotnet/aspire/database/mongodb-component?branch=pr-en-us-846) |
| [docs/database/mysql-component.md](https://github.com/dotnet/docs-aspire/blob/3dd98d00f6295a9d036113d01962b8f4eb2d53a6/docs/database/mysql-component.md) | [.NET Aspire MySQL database component](https://review.learn.microsoft.com/en-us/dotnet/aspire/database/mysql-component?branch=pr-en-us-846) |
| [docs/database/mysql-entity-framework-component.md](https://github.com/dotnet/docs-aspire/blob/3dd98d00f6295a9d036113d01962b8f4eb2d53a6/docs/database/mysql-entity-framework-component.md) | [MySQL Entity Framework Component](https://review.learn.microsoft.com/en-us/dotnet/aspire/database/mysql-entity-framework-component?branch=pr-en-us-846) |
| [docs/database/oracle-entity-framework-component.md](https://github.com/dotnet/docs-aspire/blob/3dd98d00f6295a9d036113d01962b8f4eb2d53a6/docs/database/oracle-entity-framework-component.md) | [.NET Aspire Oracle Entity Framework Component](https://review.learn.microsoft.com/en-us/dotnet/aspire/database/oracle-entity-framework-component?branch=pr-en-us-846) |
| [docs/database/postgresql-component.md](https://github.com/dotnet/docs-aspire/blob/3dd98d00f6295a9d036113d01962b8f4eb2d53a6/docs/database/postgresql-component.md) | [docs/database/postgresql-component](https://review.learn.microsoft.com/en-us/dotnet/aspire/database/postgresql-component?branch=pr-en-us-846) |
| [docs/database/postgresql-entity-framework-component.md](https://github.com/dotnet/docs-aspire/blob/3dd98d00f6295a9d036113d01962b8f4eb2d53a6/docs/database/postgresql-entity-framework-component.md) | [.NET Aspire PostgreSQL Entity Framework Core component](https://review.learn.microsoft.com/en-us/dotnet/aspire/database/postgresql-entity-framework-component?branch=pr-en-us-846) |
| [docs/database/sql-server-component.md](https://github.com/dotnet/docs-aspire/blob/3dd98d00f6295a9d036113d01962b8f4eb2d53a6/docs/database/sql-server-component.md) | [.NET Aspire SQL Server component](https://review.learn.microsoft.com/en-us/dotnet/aspire/database/sql-server-component?branch=pr-en-us-846) |
| [docs/database/sql-server-entity-framework-component.md](https://github.com/dotnet/docs-aspire/blob/3dd98d00f6295a9d036113d01962b8f4eb2d53a6/docs/database/sql-server-entity-framework-component.md) | [.NET Aspire SqlServer Entity Framework Core component](https://review.learn.microsoft.com/en-us/dotnet/aspire/database/sql-server-entity-framework-component?branch=pr-en-us-846) |
| [docs/fundamentals/components-overview.md](https://github.com/dotnet/docs-aspire/blob/3dd98d00f6295a9d036113d01962b8f4eb2d53a6/docs/fundamentals/components-overview.md) | [docs/fundamentals/components-overview](https://review.learn.microsoft.com/en-us/dotnet/aspire/fundamentals/components-overview?branch=pr-en-us-846) |
| [docs/fundamentals/health-checks.md](https://github.com/dotnet/docs-aspire/blob/3dd98d00f6295a9d036113d01962b8f4eb2d53a6/docs/fundamentals/health-checks.md) | [Health checks in .NET Aspire](https://review.learn.microsoft.com/en-us/dotnet/aspire/fundamentals/health-checks?branch=pr-en-us-846) |
| [docs/logging/seq-component.md](https://github.com/dotnet/docs-aspire/blob/3dd98d00f6295a9d036113d01962b8f4eb2d53a6/docs/logging/seq-component.md) | [.NET Aspire Seq component](https://review.learn.microsoft.com/en-us/dotnet/aspire/logging/seq-component?branch=pr-en-us-846) |
| [docs/messaging/azure-event-hubs-component.md](https://github.com/dotnet/docs-aspire/blob/3dd98d00f6295a9d036113d01962b8f4eb2d53a6/docs/messaging/azure-event-hubs-component.md) | [.NET Aspire Azure Event Hubs component](https://review.learn.microsoft.com/en-us/dotnet/aspire/messaging/azure-event-hubs-component?branch=pr-en-us-846) |
| [docs/messaging/azure-service-bus-component.md](https://github.com/dotnet/docs-aspire/blob/3dd98d00f6295a9d036113d01962b8f4eb2d53a6/docs/messaging/azure-service-bus-component.md) | [.NET Aspire Azure Service Bus component](https://review.learn.microsoft.com/en-us/dotnet/aspire/messaging/azure-service-bus-component?branch=pr-en-us-846) |
| [docs/messaging/kafka-component.md](https://github.com/dotnet/docs-aspire/blob/3dd98d00f6295a9d036113d01962b8f4eb2d53a6/docs/messaging/kafka-component.md) | [docs/messaging/kafka-component](https://review.learn.microsoft.com/en-us/dotnet/aspire/messaging/kafka-component?branch=pr-en-us-846) |
| [docs/messaging/nats-component.md](https://github.com/dotnet/docs-aspire/blob/3dd98d00f6295a9d036113d01962b8f4eb2d53a6/docs/messaging/nats-component.md) | [.NET Aspire NATS component](https://review.learn.microsoft.com/en-us/dotnet/aspire/messaging/nats-component?branch=pr-en-us-846) |
| [docs/messaging/rabbitmq-client-component.md](https://github.com/dotnet/docs-aspire/blob/3dd98d00f6295a9d036113d01962b8f4eb2d53a6/docs/messaging/rabbitmq-client-component.md) | [.NET Aspire RabbitMQ component](https://review.learn.microsoft.com/en-us/dotnet/aspire/messaging/rabbitmq-client-component?branch=pr-en-us-846) |
| [docs/security/azure-security-key-vault-component.md](https://github.com/dotnet/docs-aspire/blob/3dd98d00f6295a9d036113d01962b8f4eb2d53a6/docs/security/azure-security-key-vault-component.md) | [.NET Aspire Azure Key Vault component](https://review.learn.microsoft.com/en-us/dotnet/aspire/security/azure-security-key-vault-component?branch=pr-en-us-846) |
| [docs/storage/azure-storage-blobs-component.md](https://github.com/dotnet/docs-aspire/blob/3dd98d00f6295a9d036113d01962b8f4eb2d53a6/docs/storage/azure-storage-blobs-component.md) | [.NET Aspire Azure Blob Storage component](https://review.learn.microsoft.com/en-us/dotnet/aspire/storage/azure-storage-blobs-component?branch=pr-en-us-846) |
| [docs/storage/azure-storage-queues-component.md](https://github.com/dotnet/docs-aspire/blob/3dd98d00f6295a9d036113d01962b8f4eb2d53a6/docs/storage/azure-storage-queues-component.md) | [docs/storage/azure-storage-queues-component](https://review.learn.microsoft.com/en-us/dotnet/aspire/storage/azure-storage-queues-component?branch=pr-en-us-846) |
| [docs/storage/azure-storage-tables-component.md](https://github.com/dotnet/docs-aspire/blob/3dd98d00f6295a9d036113d01962b8f4eb2d53a6/docs/storage/azure-storage-tables-component.md) | [.NET Aspire Azure Data Tables component](https://review.learn.microsoft.com/en-us/dotnet/aspire/storage/azure-storage-tables-component?branch=pr-en-us-846) |

</details>


<!-- PREVIEW-TABLE-END -->