### PR TITLE
Fix storage worker resource name.

### DIFF
--- a/docs/storage/snippets/tutorial/AspireStorage/AspireStorage.AppHost/Program.cs
+++ b/docs/storage/snippets/tutorial/AspireStorage/AspireStorage.AppHost/Program.cs
@@ -16,7 +16,7 @@ builder.AddProject<Projects.AspireStorage>("aspirestorage")
     .WithReference(blobs)
     .WithReference(queues);
 
-builder.AddProject<Projects.AspireStorage_Worker>("aspirestorage.worker")
+builder.AddProject<Projects.AspireStorage_Worker>("aspirestorage-worker")
     .WithReference(queues);
 
 var app = builder.Build();


### PR DESCRIPTION
## Summary

Resource name had a `.` in the name which is not allowed.

Fixes #859