### PR TITLE
Fix dashboard login verbiage

### DIFF
--- a/docs/fundamentals/dashboard/explore.md
+++ b/docs/fundamentals/dashboard/explore.md
@@ -21,7 +21,7 @@ The screenshots featured in this article showcase the dark theme. For more detai
 
 When you run a .NET Aspire app host, the orchestrator starts up all the app's dependent resources and then opens a browser window to the dashboard. The .NET Aspire dashboard requires token-based authentication for its users because it displays environment variables and other sensitive information.
 
-When the dashboard is launched from Visual Studio or Visual Studio Code (with the [C# Dev Kit extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csdevkit)), the login page is bypassed, and the dashboard opens directly. This is the typical developer <kbd>F5</kbd> experience, and the authentication login flow is automated by the .NET Aspire tooling.
+When the dashboard is launched from Visual Studio or Visual Studio Code (with the [C# Dev Kit extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csdevkit)), the browser is automatically logged in, and the dashboard opens directly. This is the typical developer <kbd>F5</kbd> experience, and the authentication login flow is automated by the .NET Aspire tooling.
 
 However, if you start the app host from the command line, you're presented with the login page. The console window displays a URL that you can click on to open the dashboard in your browser.
 


### PR DESCRIPTION
## Summary

Fix dashboard login verbiage.

Fixes #809


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/dashboard/explore.md](https://github.com/dotnet/docs-aspire/blob/8c079039e87741042a7180d11b6d8b9991f937f8/docs/fundamentals/dashboard/explore.md) | [Explore the .NET Aspire dashboard](https://review.learn.microsoft.com/en-us/dotnet/aspire/fundamentals/dashboard/explore?branch=pr-en-us-864) |

<!-- PREVIEW-TABLE-END -->