### PR TITLE
point to preview container image for docker run command

### DIFF
--- a/docs/fundamentals/dashboard/overview.md
+++ b/docs/fundamentals/dashboard/overview.md
@@ -23,7 +23,7 @@ The .NET Aspire dashboard is also shipped as a Docker image and can be used stan
 
 ```bash
 docker run --rm -it -p 18888:18888 -p 4317:18889 -d --name aspire-dashboard \
-    mcr.microsoft.com/dotnet/aspire-dashboard:8.0.0
+    mcr.microsoft.com/dotnet/nightly/aspire-dashboard:8.0-preview
 ```
 
 The preceding Docker command:


### PR DESCRIPTION
## Summary

Command for docker run was pointing to the wrong image url.

```
Unable to find image 'mcr.microsoft.com/dotnet/nightly/aspire-dashboard:8.0.0' locally
docker: Error response from daemon: manifest for mcr.microsoft.com/dotnet/nightly/aspire-dashboard:8.0.0 not found: manifest unknown: manifest tagged by "8.0.0" is not found.
See 'docker run --help'.
```


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/dashboard/overview.md](https://github.com/dotnet/docs-aspire/blob/82bb9c1e8ae1b2fd8b065314b5cd11fe3ff91861/docs/fundamentals/dashboard/overview.md) | [.NET Aspire dashboard overview](https://review.learn.microsoft.com/en-us/dotnet/aspire/fundamentals/dashboard/overview?branch=pr-en-us-944) |

<!-- PREVIEW-TABLE-END -->