### PR TITLE
Fix wrong nuget package in installation documentation.

### DIFF
--- a/docs/database/qdrant-component.md
+++ b/docs/database/qdrant-component.md
@@ -16,7 +16,7 @@ To get started with the .NET Aspire Qdrant component, install the [Aspire.Qdrant
 ### [.NET CLI](#tab/dotnet-cli)
 
 ```dotnetcli
-dotnet add package Qdrant.Client
+dotnet add package Aspire.Qdrant.Client
 ```
 
 ### [PackageReference](#tab/package-reference)


### PR DESCRIPTION
The command to install `Aspire.Qdrant.Client` installed `Qdrant.Client`.  


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/database/qdrant-component.md](https://github.com/dotnet/docs-aspire/blob/468220498daf2e89710d06d1121166e4f9a42467/docs/database/qdrant-component.md) | [.NET Aspire Qdrant component](https://review.learn.microsoft.com/en-us/dotnet/aspire/database/qdrant-component?branch=pr-en-us-969) |

<!-- PREVIEW-TABLE-END -->