### PR TITLE
Update aca-deployment-azd-in-depth.md - Add missing dotnet cli command argument

### DIFF
--- a/docs/deployment/azure/aca-deployment-azd-in-depth.md
+++ b/docs/deployment/azure/aca-deployment-azd-in-depth.md
@@ -45,7 +45,7 @@ The `azd init` workflow provides customized supported for .NET Aspire projects. 
 
 :::image type="content" source="media/azd-internals.png" alt-text="Illustration of internal processing of `azd` when deploying .NET Aspire application.":::
 
-1. When `azd` targets a .NET Aspire application it starts the AppHost with a special command (`dotnet run --project AppHost.csproj -- --publisher manifest`), which produces the Aspire [manifest file](../manifest-format.md).
+1. When `azd` targets a .NET Aspire application it starts the AppHost with a special command (`dotnet run --project AppHost.csproj --output-path manifest.json --publisher manifest`), which produces the Aspire [manifest file](../manifest-format.md).
 1. The manifest file is interrogated by the `azd provision` sub-command logic to generate Bicep files in-memory only (by default).
 1. After generating the Bicep files, a deployment is triggered using Azure's ARM APIs targeting the subscription and resource group provided earlier.
 1. Once the underlying Azure resources are configured, the `azd deploy` sub-command logic is executed which uses the same Aspire manifest file.


### PR DESCRIPTION
## Summary

Assed missing '--output-path' parameter from dotnet cli command under point 1 of 'How Azure Developer CLI integration works' section

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/deployment/azure/aca-deployment-azd-in-depth.md](https://github.com/dotnet/docs-aspire/blob/aecc13ee479dadec62551b8fbe4fb7af683134da/docs/deployment/azure/aca-deployment-azd-in-depth.md) | [Deploy a .NET Aspire app to Azure Container Apps using the Azure Developer CLI (in-depth guide)](https://review.learn.microsoft.com/en-us/dotnet/aspire/deployment/azure/aca-deployment-azd-in-depth?branch=pr-en-us-973) |

<!-- PREVIEW-TABLE-END -->