### PR TITLE
Fixes typo in .NET Aspire Overview

### DIFF
--- a/docs/get-started/aspire-overview.md
+++ b/docs/get-started/aspire-overview.md
@@ -59,7 +59,7 @@ For more information, see [.NET Aspire orchestration overview](../fundamentals/a
 
 [.NET Aspire components](../fundamentals/components-overview.md) are NuGet packages designed to simplify connections to popular services and platforms, such as Redis or PostgreSQL. .NET Aspire components handle many cloud-native concerns for you through standardized configuration patterns, such as adding health checks and telemetry.
 
-Each component is designed to work with .NET Aspire orchestration, and they're configurations are injected automatically by simply referencing named resources. In other words, if _Example.ServiceFoo_ references _Example.ServiceBar_, _Example.ServiceFoo_ inherits the component's required configurations to allow them to communicate with each other automatically.
+Each component is designed to work with .NET Aspire orchestration, and their configurations are injected automatically by simply referencing named resources. In other words, if _Example.ServiceFoo_ references _Example.ServiceBar_, _Example.ServiceFoo_ inherits the component's required configurations to allow them to communicate with each other automatically.
 
 For example, consider the following code using the .NET Aspire Service Bus component:
 


### PR DESCRIPTION
Hey! I was just reading up on Aspire and noticed this small typo.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/get-started/aspire-overview.md](https://github.com/dotnet/docs-aspire/blob/41fe63700d9c32fa7363db668beac2cf3bc72a29/docs/get-started/aspire-overview.md) | [.NET Aspire overview](https://review.learn.microsoft.com/en-us/dotnet/aspire/get-started/aspire-overview?branch=pr-en-us-979) |

<!-- PREVIEW-TABLE-END -->