### PR TITLE
Add link to supporting content for `az group delete` and help macOS users create .github

### DIFF
--- a/docs/deployment/azure/aca-deployment-github-actions.md
+++ b/docs/deployment/azure/aca-deployment-github-actions.md
@@ -1,7 +1,7 @@
 ---
 title: Deploy a .NET Aspire app using the Azure Developer CLI and GitHub Actions
 description: Learn how to use `azd` and GitHub Actions to deploy .NET Aspire apps.
-ms.date: 12/18/2023
+ms.date: 05/30/2024
 zone_pivot_groups: deployment-platform
 ms.custom: devx-track-extended-azdevcli
 ---
@@ -67,6 +67,13 @@ As a starting point, this article assumes that you've created a .NET Aspire app 
 Although `azd` generated some essential template files for you, the project still needs a GitHub Actions workflow file to support provisioning and deployments using CI/CD.
 
 1. Create an empty _.github_ folder at the root of your project. `azd` uses this directory by default to discover GitHub Actions workflow files.
+
+    > [!TIP]
+    > If you're on macOS user and you're struggling to create a folder with a leading `.`, you can use the terminal to create the folder. Open the terminal and navigate to the root of your project. Run the following command to create the folder:
+    >
+    > ```bash
+    > mkdir .github
+    > ```
 
 1. Inside the new _.github_ folder, create another folder called _workflows_ (you'll end up with _.github/workflows_).
 

--- a/docs/includes/clean-up-resources.md
+++ b/docs/includes/clean-up-resources.md
@@ -5,3 +5,5 @@ Run the following Azure CLI command to delete the resource group when you no lon
 ```azurecli
 az group delete --name <your-resource-group-name>
 ```
+
+For more information, see [Clean up resources in Azure](/cli/azure/group?view=azure-cli-latest#az-group-delete).


### PR DESCRIPTION
## Summary

Add link to supporting content for `az group delete` and help macOS users create _.github_.

Fixes #972


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/deployment/azure/aca-deployment-github-actions.md](https://github.com/dotnet/docs-aspire/blob/a9343b7f4167293b920fb9c413de0e5c95f02dc4/docs/deployment/azure/aca-deployment-github-actions.md) | [Tutorial: Deploy a .NET Aspire app using the Azure Developer CLI and GitHub Actions](https://review.learn.microsoft.com/en-us/dotnet/aspire/deployment/azure/aca-deployment-github-actions?branch=pr-en-us-1018) |

<!-- PREVIEW-TABLE-END -->