### PR TITLE
Fix AzureProvisioner config docs

### DIFF
--- a/docs/deployment/azure/local-provisioning.md
+++ b/docs/deployment/azure/local-provisioning.md
@@ -118,18 +118,18 @@ With the [Aspire.Hosting.Azure](https://nuget.org/packages/Aspire.Hosting.Azure)
 ```json
 {
   "Azure": {
-    "CredentialStore": "AzureCLI"
+    "CredentialSource": "AzureCli"
   }
 }
 ```
 
-As with all [configuration-based settings](/dotnet/core/extensions/configuration), you can configure these with alternative providers, such as [user secrets](/aspnet/core/security/app-secrets) or [environment variables](/dotnet/core/extensions/configuration-providers#environment-variable-configuration-provider). The `Azure:CredentialStore` value can be set to one of the following values:
+As with all [configuration-based settings](/dotnet/core/extensions/configuration), you can configure these with alternative providers, such as [user secrets](/aspnet/core/security/app-secrets) or [environment variables](/dotnet/core/extensions/configuration-providers#environment-variable-configuration-provider). The `Azure:CredentialSource` value can be set to one of the following values:
 
-- `AzureCLI`: Delegates to the <xref:Azure.Identity.AzureCliCredential>.
+- `AzureCli`: Delegates to the <xref:Azure.Identity.AzureCliCredential>.
 - `AzurePowerShell`: Delegates to the <xref:Azure.Identity.AzurePowerShellCredential>.
 - `VisualStudio`: Delegates to the <xref:Azure.Identity.VisualStudioCredential>.
 - `VisualStudioCode`: Delegates to the <xref:Azure.Identity.VisualStudioCodeCredential>.
-- `AzureDeveloperCLI`: Delegates to the <xref:Azure.Identity.AzureDeveloperCliCredential>.
+- `AzureDeveloperCli`: Delegates to the <xref:Azure.Identity.AzureDeveloperCliCredential>.
 - `InteractiveBrowser`: Delegates to the <xref:Azure.Identity.InteractiveBrowserCredential>.
 
 ### Tooling support


### PR DESCRIPTION
The docs are wrong, currently. See the corresponding code: https://github.com/dotnet/aspire/blob/26742d30609f8a96c6eb41aa80f64496bb158ea6/src/Aspire.Hosting.Azure/Provisioning/AzureProvisionerOptions.cs#L23-L27

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/deployment/azure/local-provisioning.md](https://github.com/dotnet/docs-aspire/blob/b5d0c232aa53e67736bf0ac1392716e32f833597/docs/deployment/azure/local-provisioning.md) | [Local Azure provisioning](https://review.learn.microsoft.com/en-us/dotnet/aspire/deployment/azure/local-provisioning?branch=pr-en-us-1021) |

<!-- PREVIEW-TABLE-END -->