### PR TITLE
Remove .NET CLI command that was mistakenly included.

### DIFF
--- a/docs/get-started/add-aspire-existing-app.md
+++ b/docs/get-started/add-aspire-existing-app.md
@@ -38,9 +38,9 @@ This article uses a .NET 8 solution with three projects:
 - **Products**. This example Web API returns a list of products in the catalog and their properties.
 - **Store**. This example Blazor Web App displays the product catalog to website visitors.
 
-Open and start debugging the project to examine its default behavior:
-
 :::zone pivot="visual-studio"
+
+Open and start debugging the project to examine its default behavior:
 
 1. Start Visual Studio and then select **File** > **Open** > **Project/Solution**.
 1. Navigate to the top level folder of the solution you cloned, select **eShopLite.sln**, and then select **Open**.
@@ -142,8 +142,6 @@ Open and start debugging the project to examine its default behavior:
 :::zone-end
 :::zone pivot="dotnet-cli"
 
-[!INCLUDE [dotnet-cli-file-new](../includes/dotnet-cli-file-new.md)]
-
 1. Open a terminal window and change directories into the newly cloned repository.
 1. To start the _Products_ app, run the following command:
 
@@ -153,7 +151,7 @@ Open and start debugging the project to examine its default behavior:
 
 1. A browser page opens, displaying the JSON for the products.
 1. In a separate terminal window, again change directories to cloned repository.
-1. Start the _Store) app by running the following command:
+1. Start the _Store_ app by running the following command:
 
     ```dotnetcli
     dotnet run --project ./Store/Store.csproj

--- a/docs/get-started/add-aspire-existing-app.md
+++ b/docs/get-started/add-aspire-existing-app.md
@@ -38,9 +38,9 @@ This article uses a .NET 8 solution with three projects:
 - **Products**. This example Web API returns a list of products in the catalog and their properties.
 - **Store**. This example Blazor Web App displays the product catalog to website visitors.
 
-:::zone pivot="visual-studio"
-
 Open and start debugging the project to examine its default behavior:
+
+:::zone pivot="visual-studio"
 
 1. Start Visual Studio and then select **File** > **Open** > **Project/Solution**.
 1. Navigate to the top level folder of the solution you cloned, select **eShopLite.sln**, and then select **Open**.


### PR DESCRIPTION
## Summary

Remove .NET CLI command that was mistakenly included.

Fixes #1027


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/get-started/add-aspire-existing-app.md](https://github.com/dotnet/docs-aspire/blob/06e2ed65989989f6acfc3a031ac25b3c46c45399/docs/get-started/add-aspire-existing-app.md) | [Tutorial: Add .NET Aspire to an existing .NET app](https://review.learn.microsoft.com/en-us/dotnet/aspire/get-started/add-aspire-existing-app?branch=pr-en-us-1032) |

<!-- PREVIEW-TABLE-END -->