### PR TITLE
Remove invalid trailing comma in config example

### DIFF
--- a/docs/deployment/azure/local-provisioning.md
+++ b/docs/deployment/azure/local-provisioning.md
@@ -99,7 +99,7 @@ Consider the following example _:::no-loc text="appsettings.json":::_ configurat
     "SubscriptionId": "<Your subscription id>",
     "AllowResourceGroupCreation": true,
     "ResourceGroup": "<Valid resource group name>",
-    "Location": "<Valid Azure location>",
+    "Location": "<Valid Azure location>"
   }
 }
 ```


### PR DESCRIPTION
Make the JSON valid, remove the squiggly

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/deployment/azure/local-provisioning.md](https://github.com/dotnet/docs-aspire/blob/f217872a64d3f3f2e19c942e29f1bb77902d6224/docs/deployment/azure/local-provisioning.md) | [Local Azure provisioning](https://review.learn.microsoft.com/en-us/dotnet/aspire/deployment/azure/local-provisioning?branch=pr-en-us-1061) |

<!-- PREVIEW-TABLE-END -->