### PR TITLE
Add an overview of Stack Exchange Redis caching

### DIFF
--- a/docs/caching/caching-components-deployment.md
+++ b/docs/caching/caching-components-deployment.md
@@ -1,7 +1,7 @@
 ---
 title: Deploy a .NET Aspire app that connects to Redis Cache to Azure
 description: Learn how to deploy a .NET Aspire app that connects to Redis Cache to Azure
-ms.date: 05/14/2024
+ms.date: 06/11/2024
 ms.topic: how-to
 ---
 

--- a/docs/caching/caching-components.md
+++ b/docs/caching/caching-components.md
@@ -1,7 +1,7 @@
 ---
 title: Implement caching with .NET Aspire components
 description: Learn how to connect to Redis and cache data using .NET Aspire components.
-ms.date: 06/05/2024
+ms.date: 06/11/2024
 ms.topic: tutorial
 ---
 
@@ -96,7 +96,7 @@ Configuring connection string with this method, while functional, requires dupli
 
 ## Configure the UI with output caching
 
-1. Add the [.NET Aspire StackExchange Redis output caching](stackexchange-redis-output-caching-component.md) component packages to your `AspireRedis.Web` app:
+1. Add the [.NET Aspire Stack Exchange Redis output caching](stackexchange-redis-output-caching-component.md) component packages to your `AspireRedis.Web` app:
 
     ```dotnetcli
     dotnet add package Aspire.StackExchange.Redis.OutputCaching
@@ -130,7 +130,7 @@ Configuring connection string with this method, while functional, requires dupli
 
 ## Configure the API with distributed caching
 
-1. Add the [.NET Aspire StackExchange Redis distributed caching](stackexchange-redis-output-caching-component.md) component packages to your `AspireRedis.ApiService` app:
+1. Add the [.NET Aspire Stack Exchange Redis distributed caching](stackexchange-redis-output-caching-component.md) component packages to your `AspireRedis.ApiService` app:
 
     ```dotnetcli
     dotnet add package Aspire.StackExchange.Redis.DistributedCaching

--- a/docs/caching/includes/redis-app-host.md
+++ b/docs/caching/includes/redis-app-host.md
@@ -15,4 +15,4 @@ dotnet add package Aspire.Hosting.Redis
 
 ---
 
-In your app host project, register the .NET Aspire StackExchange Redis as a resource using the <xref:Aspire.Hosting.RedisBuilderExtensions.AddRedis%2A> method and consume the service using the following methods:
+In your app host project, register the .NET Aspire Stack Exchange Redis as a resource using the <xref:Aspire.Hosting.RedisBuilderExtensions.AddRedis%2A> method and consume the service using the following methods:

--- a/docs/caching/stackexchange-redis-caching-overview.md
+++ b/docs/caching/stackexchange-redis-caching-overview.md
@@ -1,0 +1,40 @@
+---
+title: Stack Exchange Redis caching overview
+description: Learn about Stack Exchange Redis caching and how to use it in your applications.
+ms.date: 06/11/2024
+---
+
+# Stack Exchange Redis caching overview
+
+With .NET Aspire, there are several ways to use caching in your applications. One popular option is to use [Stack Exchange Redis](https://stackexchange.github.io/StackExchange.Redis), which is a high-performance data store that can be used to store frequently accessed data. This article provides an overview of Stack Exchange Redis caching and links to resources that help you use it in your applications.
+
+To use multiple Redis caching components in your application, see the [Tutorial: Implement caching with .NET Aspire components](caching-components.md). If you're interested in using the Redis Cache for Azure, see the [Tutorial: Deploy a .NET Aspire app with a Redis Cache to Azure](caching-components-deployment.md).
+
+## Caching
+
+Caching is a technique used to store frequently accessed data in memory. This helps to reduce the time it takes to retrieve the data from the original source, such as a database or a web service. Caching can significantly improve the performance of an application by reducing the number of requests made to the original source. To access the Redis `IConnectionMultiplexer` object, you use the `Aspire.StackExchange.Redis` NuGet package:
+
+> [!div class="nextstepaction"]
+> [.NET Aspire Stack Exchange Redis component](stackexchange-redis-component.md)
+
+## Distributed caching
+
+Distributed caching is a type of caching that stores data across multiple servers. This allows the data to be shared between multiple instances of an application, which can help to improve scalability and performance. Distributed caching can be used to store a wide variety of data, such as session state, user profiles, and frequently accessed data. To use Redis distributed caching in your application (the `IDistributedCache` interface), use the `Aspire.StackExchange.Redis.DistributedCaching` NuGet package:
+
+> [!div class="nextstepaction"]
+> [.NET Aspire Stack Exchange Redis distributed caching component](stackexchange-redis-distributed-caching-component.md)
+
+## Output caching
+
+Output caching is a type of caching that stores the output of a web page or API response. This allows the response to be served directly from the cache, rather than generating it from scratch each time. Output caching can help to improve the performance of a web application by reducing the time it takes to generate a response. To use declarative Redis output caching with either the `OutputCache` attribute or the `CacheOutput` method in your application, use the `Aspire.StackExchange.Redis.OutputCaching` NuGet package:
+
+> [!div class="nextstepaction"]
+> [.NET Aspire Stack Exchange Redis output caching component](stackexchange-redis-output-caching-component.md)
+
+## See also
+
+- [Caching in .NET](/dotnet/core/extensions/caching)
+- [Overview of Caching in ASP.NET Core](/aspnet/core/performance/caching/overview)
+- [Distributed caching in .NET](/dotnet/core/extensions/caching#distributed-caching)
+- [Distributed caching in ASP.NET Core](/aspnet/core/performance/caching/distributed)
+- [Output caching middleware in ASP.NET Core](/aspnet/core/performance/caching/output)

--- a/docs/caching/stackexchange-redis-caching-overview.md
+++ b/docs/caching/stackexchange-redis-caching-overview.md
@@ -8,7 +8,7 @@ ms.date: 06/11/2024
 
 With .NET Aspire, there are several ways to use caching in your applications. One popular option is to use [Stack Exchange Redis](https://stackexchange.github.io/StackExchange.Redis), which is a high-performance data store that can be used to store frequently accessed data. This article provides an overview of Stack Exchange Redis caching and links to resources that help you use it in your applications.
 
-To use multiple Redis caching components in your application, see the [Tutorial: Implement caching with .NET Aspire components](caching-components.md). If you're interested in using the Redis Cache for Azure, see the [Tutorial: Deploy a .NET Aspire app with a Redis Cache to Azure](caching-components-deployment.md).
+To use multiple Redis caching components in your application, see [Tutorial: Implement caching with .NET Aspire components](caching-components.md). If you're interested in using the Redis Cache for Azure, see [Tutorial: Deploy a .NET Aspire app with a Redis Cache to Azure](caching-components-deployment.md).
 
 ## Caching
 

--- a/docs/caching/stackexchange-redis-caching.md
+++ b/docs/caching/stackexchange-redis-caching.md
@@ -1,7 +1,0 @@
----
-ms.date: 06/11/2024
----
-
-# Stack Exchange Redis caching overview
-
-## 

--- a/docs/caching/stackexchange-redis-caching.md
+++ b/docs/caching/stackexchange-redis-caching.md
@@ -1,0 +1,7 @@
+---
+ms.date: 06/11/2024
+---
+
+# Stack Exchange Redis caching overview
+
+## 

--- a/docs/caching/stackexchange-redis-component.md
+++ b/docs/caching/stackexchange-redis-component.md
@@ -1,17 +1,17 @@
 ---
-title: .NET Aspire StackExchange Redis component
-description: This article describes the .NET Aspire StackExchange Redis component features and capabilities
+title: .NET Aspire Stack Exchange Redis component
+description: This article describes the .NET Aspire Stack Exchange Redis component features and capabilities
 ms.topic: how-to
-ms.date: 06/05/2024
+ms.date: 06/11/2024
 ---
 
-# .NET Aspire StackExchange Redis component
+# .NET Aspire Stack Exchange Redis component
 
-In this article, you learn how to use the .NET Aspire StackExchange Redis component. The `Aspire.StackExchange.Redis` library is used to register an [IConnectionMultiplexer](https://stackexchange.github.io/StackExchange.Redis/Basics) in the DI container for connecting to a [Redis](https://redis.io/) server. It enables corresponding health checks, logging and telemetry.
+In this article, you learn how to use the .NET Aspire Stack Exchange Redis component. The `Aspire.StackExchange.Redis` library is used to register an [IConnectionMultiplexer](https://stackexchange.github.io/StackExchange.Redis/Basics) in the DI container for connecting to a [Redis](https://redis.io/) server. It enables corresponding health checks, logging and telemetry.
 
 ## Get started
 
-To get started with the .NET Aspire StackExchange Redis component, install the [Aspire.StackExchange.Redis](https://www.nuget.org/packages/Aspire.StackExchange.Redis) NuGet package.
+To get started with the .NET Aspire Stack Exchange Redis component, install the [Aspire.StackExchange.Redis](https://www.nuget.org/packages/Aspire.StackExchange.Redis) NuGet package.
 
 ### [.NET CLI](#tab/dotnet-cli)
 
@@ -68,7 +68,7 @@ builder.AddRedis("cache");
 
 ## Configuration
 
-The .NET Aspire StackExchange Redis component provides multiple options to configure the Redis connection based on the requirements and conventions of your project.
+The .NET Aspire Stack Exchange Redis component provides multiple options to configure the Redis connection based on the requirements and conventions of your project.
 
 ### Use a connection string
 
@@ -88,11 +88,11 @@ And then the connection string will be retrieved from the `ConnectionStrings` co
 }
 ```
 
-For more information on how to format this connection string, see the [StackExchange Redis configuration docs](https://stackexchange.github.io/StackExchange.Redis/Configuration.html#basic-configuration-strings).
+For more information on how to format this connection string, see the [Stack Exchange Redis configuration docs](https://stackexchange.github.io/StackExchange.Redis/Configuration.html#basic-configuration-strings).
 
 ### Use configuration providers
 
-The .NET Aspire StackExchange Redis component supports <xref:Microsoft.Extensions.Configuration?displayProperty=fullName>. It loads the <xref:Aspire.StackExchange.Redis.StackExchangeRedisSettings> from configuration by using the `Aspire:StackExchange:Redis` key. Example _:::no-loc text="appsettings.json":::_ that configures some of the options:
+The .NET Aspire Stack Exchange Redis component supports <xref:Microsoft.Extensions.Configuration?displayProperty=fullName>. It loads the <xref:Aspire.StackExchange.Redis.StackExchangeRedisSettings> from configuration by using the `Aspire:StackExchange:Redis` key. Example _:::no-loc text="appsettings.json":::_ that configures some of the options:
 
 ```json
 {
@@ -123,7 +123,7 @@ builder.AddRedis(
 
 [!INCLUDE [component-health-checks](../includes/component-health-checks.md)]
 
-The .NET Aspire StackExchange Redis component handles the following:
+The .NET Aspire Stack Exchange Redis component handles the following:
 
 - Adds the `StackExchange.Redis` health check, tries to open the connection and throws when it fails.
 - Integrates with the `/health` HTTP endpoint, which specifies all registered health checks must pass for app to be considered ready to accept traffic
@@ -132,22 +132,22 @@ The .NET Aspire StackExchange Redis component handles the following:
 
 ### Logging
 
-The .NET Aspire StackExchange Redis component uses the following log categories:
+The .NET Aspire Stack Exchange Redis component uses the following log categories:
 
 - `Aspire.StackExchange.Redis`
 
 ### Tracing
 
-The .NET Aspire StackExchange Redis component will emit the following tracing activities using OpenTelemetry:
+The .NET Aspire Stack Exchange Redis component will emit the following tracing activities using OpenTelemetry:
 
 - "OpenTelemetry.Instrumentation.StackExchangeRedis"
 
 ### Metrics
 
-The .NET Aspire StackExchange Redis component currently doesn't support metrics by default due to limitations with the `StackExchange.Redis` library.
+The .NET Aspire Stack Exchange Redis component currently doesn't support metrics by default due to limitations with the `StackExchange.Redis` library.
 
 ## See also
 
-- [StackExchange Redis docs](https://stackexchange.github.io/StackExchange.Redis/)
+- [Stack Exchange Redis docs](https://stackexchange.github.io/StackExchange.Redis/)
 - [.NET Aspire components](../fundamentals/components-overview.md)
 - [.NET Aspire GitHub repo](https://github.com/dotnet/aspire)

--- a/docs/caching/stackexchange-redis-distributed-caching-component.md
+++ b/docs/caching/stackexchange-redis-distributed-caching-component.md
@@ -1,17 +1,17 @@
 ---
-title: .NET Aspire StackExchange Redis distributed caching component
-description: This article describes the .NET Aspire StackExchange Redis distributed caching component features and capabilities
+title: .NET Aspire Stack Exchange Redis distributed caching component
+description: This article describes the .NET Aspire Stack Exchange Redis distributed caching component features and capabilities
 ms.topic: how-to
-ms.date: 06/05/2024
+ms.date: 06/11/2024
 ---
 
-# .NET Aspire StackExchange Redis distributed caching component
+# .NET Aspire Stack Exchange Redis distributed caching component
 
-In this article, you learn how to use the .NET Aspire StackExchange Redis distributed caching component. The `Aspire.StackExchange.Redis.DistributedCaching` library is used to register an [IDistributedCache](https://stackexchange.github.io/StackExchange.Redis/Basics) provider for connecting to [Redis](https://redis.io/) server. It enables corresponding health checks, logging and telemetry.
+In this article, you learn how to use the .NET Aspire Stack Exchange Redis distributed caching component. The `Aspire.StackExchange.Redis.DistributedCaching` library is used to register an [IDistributedCache](https://stackexchange.github.io/StackExchange.Redis/Basics) provider for connecting to [Redis](https://redis.io/) server. It enables corresponding health checks, logging and telemetry.
 
 ## Get started
 
-To get started with the .NET Aspire StackExchange Redis distributed caching component, install the [Aspire.StackExchange.Redis.DistributedCaching](https://www.nuget.org/packages/Aspire.StackExchange.Redis.DistributedCaching) NuGet package.
+To get started with the .NET Aspire Stack Exchange Redis distributed caching component, install the [Aspire.StackExchange.Redis.DistributedCaching](https://www.nuget.org/packages/Aspire.StackExchange.Redis.DistributedCaching) NuGet package.
 
 ### [.NET CLI](#tab/dotnet-cli)
 
@@ -68,7 +68,7 @@ builder.AddRedisDistributedCache("cache");
 
 ## Configuration
 
-The .NET Aspire StackExchange Redis distributed caching component provides multiple options to configure the Redis connection based on the requirements and conventions of your project.
+The .NET Aspire Stack Exchange Redis distributed caching component provides multiple options to configure the Redis connection based on the requirements and conventions of your project.
 
 ### Use a connection string
 
@@ -88,11 +88,11 @@ And then the connection string will be retrieved from the `ConnectionStrings` co
 }
 ```
 
-For more information on how to format this connection string, see the [StackExchange Redis configuration docs](https://stackexchange.github.io/StackExchange.Redis/Configuration.html#basic-configuration-strings).
+For more information on how to format this connection string, see the [Stack Exchange Redis configuration docs](https://stackexchange.github.io/StackExchange.Redis/Configuration.html#basic-configuration-strings).
 
 ### Use configuration providers
 
-The .NET Aspire StackExchange Redis distributed caching component supports <xref:Microsoft.Extensions.Configuration?displayProperty=fullName>. It loads the <xref:Aspire.StackExchange.Redis.StackExchangeRedisSettings> from configuration by using the `Aspire:StackExchange:Redis` key. Example _:::no-loc text="appsettings.json":::_ that configures some of the options:
+The .NET Aspire Stack Exchange Redis distributed caching component supports <xref:Microsoft.Extensions.Configuration?displayProperty=fullName>. It loads the <xref:Aspire.StackExchange.Redis.StackExchangeRedisSettings> from configuration by using the `Aspire:StackExchange:Redis` key. Example _:::no-loc text="appsettings.json":::_ that configures some of the options:
 
 ```json
 {
@@ -131,7 +131,7 @@ builder.AddRedisDistributedCache(
 
 [!INCLUDE [component-health-checks](../includes/component-health-checks.md)]
 
-The .NET Aspire StackExchange Redis distributed caching component handles the following:
+The .NET Aspire Stack Exchange Redis distributed caching component handles the following:
 
 - Adds the `StackExchange.Redis` health check, tries to open the connection and throws when it fails.
 - Integrates with the `/health` HTTP endpoint, which specifies all registered health checks must pass for app to be considered ready to accept traffic
@@ -140,23 +140,23 @@ The .NET Aspire StackExchange Redis distributed caching component handles the fo
 
 ### Logging
 
-The .NET Aspire StackExchange Redis Distributed Caching component uses the following Log categories:
+The .NET Aspire Stack Exchange Redis Distributed Caching component uses the following Log categories:
 
 - `Aspire.StackExchange.Redis`
 - `Microsoft.Extensions.Caching.StackExchangeRedis`
 
 ### Tracing
 
-The .NET Aspire StackExchange Redis Distributed Caching component will emit the following Tracing activities using OpenTelemetry:
+The .NET Aspire Stack Exchange Redis Distributed Caching component will emit the following Tracing activities using OpenTelemetry:
 
 - "OpenTelemetry.Instrumentation.StackExchangeRedis"
 
 ### Metrics
 
-The .NET Aspire StackExchange Redis Distributed Caching component currently doesn't support metrics by default due to limitations with the `StackExchange.Redis` library.
+The .NET Aspire Stack Exchange Redis Distributed Caching component currently doesn't support metrics by default due to limitations with the `StackExchange.Redis` library.
 
 ## See also
 
-- [StackExchange Redis docs](https://stackexchange.github.io/StackExchange.Redis/)
+- [Stack Exchange Redis docs](https://stackexchange.github.io/StackExchange.Redis/)
 - [.NET Aspire components](../fundamentals/components-overview.md)
 - [.NET Aspire GitHub repo](https://github.com/dotnet/aspire)

--- a/docs/caching/stackexchange-redis-output-caching-component.md
+++ b/docs/caching/stackexchange-redis-output-caching-component.md
@@ -1,17 +1,17 @@
 ---
-title: .NET Aspire StackExchange Redis output caching Component
-description: This article describes the .NET Aspire StackExchange Redis output caching component features and capabilities
+title: .NET Aspire Stack Exchange Redis output caching Component
+description: This article describes the .NET Aspire Stack Exchange Redis output caching component features and capabilities
 ms.topic: how-to
-ms.date: 06/05/2024
+ms.date: 06/11/2024
 ---
 
-# .NET Aspire StackExchange Redis output caching component
+# .NET Aspire Stack Exchange Redis output caching component
 
-In this article, you learn how to use the .NET Aspire StackExchange Redis output caching component. The `Aspire.StackExchange.Redis.OutputCaching` library is used to register an [ASP.NET Core Output Caching](/aspnet/core/performance/caching/output) provider backed by a [Redis](https://redis.io/) server. It enables corresponding health check, logging, and telemetry.
+In this article, you learn how to use the .NET Aspire Stack Exchange Redis output caching component. The `Aspire.StackExchange.Redis.OutputCaching` library is used to register an [ASP.NET Core Output Caching](/aspnet/core/performance/caching/output) provider backed by a [Redis](https://redis.io/) server. It enables corresponding health check, logging, and telemetry.
 
 ## Get started
 
-To get started with the .NET Aspire StackExchange Redis output caching component, install the [Aspire.StackExchange.Redis.OutputCaching](https://www.nuget.org/packages/Aspire.StackExchange.Redis.OutputCaching) NuGet package.
+To get started with the .NET Aspire Stack Exchange Redis output caching component, install the [Aspire.StackExchange.Redis.OutputCaching](https://www.nuget.org/packages/Aspire.StackExchange.Redis.OutputCaching) NuGet package.
 
 ### [.NET CLI](#tab/dotnet-cli)
 
@@ -75,7 +75,7 @@ builder.AddRedisOutputCache("messaging");
 
 ## Configuration
 
-The .NET Aspire StackExchange Redis output caching component provides multiple options to configure the Redis connection based on the requirements and conventions of your project.
+The .NET Aspire Stack Exchange Redis output caching component provides multiple options to configure the Redis connection based on the requirements and conventions of your project.
 
 ### Use a connection string
 
@@ -95,11 +95,11 @@ And then the connection string will be retrieved from the `ConnectionStrings` co
 }
 ```
 
-For more information on how to format this connection string, see the [StackExchange Redis configuration docs](https://stackexchange.github.io/StackExchange.Redis/Configuration.html#basic-configuration-strings).
+For more information on how to format this connection string, see the [Stack Exchange Redis configuration docs](https://stackexchange.github.io/StackExchange.Redis/Configuration.html#basic-configuration-strings).
 
 ### Use configuration providers
 
-The .NET Aspire StackExchange Redis output caching component supports <xref:Microsoft.Extensions.Configuration>. It loads the <xref:Aspire.StackExchange.Redis.StackExchangeRedisSettings> from configuration by using the `Aspire:StackExchange:Redis` key. Example _:::no-loc text="appsettings.json":::_ that configures some of the options:
+The .NET Aspire Stack Exchange Redis output caching component supports <xref:Microsoft.Extensions.Configuration>. It loads the <xref:Aspire.StackExchange.Redis.StackExchangeRedisSettings> from configuration by using the `Aspire:StackExchange:Redis` key. Example _:::no-loc text="appsettings.json":::_ that configures some of the options:
 
 ```json
 {
@@ -138,7 +138,7 @@ builder.AddRedisOutputCache(
 
 [!INCLUDE [component-health-checks](../includes/component-health-checks.md)]
 
-The .NET Aspire StackExchange Redis output caching component handles the following:
+The .NET Aspire Stack Exchange Redis output caching component handles the following:
 
 - Adds the `StackExchange.Redis` health check, tries to open the connection and throws when it fails.
 - Integrates with the `/health` HTTP endpoint, which specifies all registered health checks must pass for app to be considered ready to accept traffic.
@@ -147,23 +147,23 @@ The .NET Aspire StackExchange Redis output caching component handles the followi
 
 ### Logging
 
-The .NET Aspire StackExchange Redis output caching component uses the following Log categories:
+The .NET Aspire Stack Exchange Redis output caching component uses the following Log categories:
 
 - `Aspire.StackExchange.Redis`
 - `Microsoft.AspNetCore.OutputCaching.StackExchangeRedis`
 
 ### Tracing
 
-The .NET Aspire StackExchange Redis output caching component will emit the following Tracing activities using OpenTelemetry:
+The .NET Aspire Stack Exchange Redis output caching component will emit the following Tracing activities using OpenTelemetry:
 
 - "OpenTelemetry.Instrumentation.StackExchangeRedis"
 
 ### Metrics
 
-The .NET Aspire StackExchange Redis output caching component currently doesn't support metrics by default due to limitations with the `StackExchange.Redis` library.
+The .NET Aspire Stack Exchange Redis output caching component currently doesn't support metrics by default due to limitations with the `StackExchange.Redis` library.
 
 ## See also
 
-- [StackExchange Redis docs](https://stackexchange.github.io/StackExchange.Redis/)
+- [Stack Exchange Redis docs](https://stackexchange.github.io/StackExchange.Redis/)
 - [.NET Aspire components](../fundamentals/components-overview.md)
 - [.NET Aspire GitHub repo](https://github.com/dotnet/aspire)

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -151,6 +151,9 @@ conceptualContent:
         - itemType: tutorial
           text: Improve app caching with .NET Aspire
           url: caching/caching-components.md
+        - itemType: overview
+          text: Stack Exchange Redis caching overview
+          url: caching/stackexchange-redis-caching-overview.md
         - itemType: how-to-guide
           text: Redis caching
           url: caching/stackexchange-redis-component.md

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -151,6 +151,8 @@ items:
         href: messaging/rabbitmq-client-component.md
       - name: Redis
         items:
+        - name: Overview
+          href: caching/stackexchange-redis-caching-overview.md
         - name: Redis caching
           displayName: caching
           href: caching/stackexchange-redis-component.md

--- a/docs/whats-new/dotnet-docs-aspire-mod1.md
+++ b/docs/whats-new/dotnet-docs-aspire-mod1.md
@@ -94,11 +94,11 @@ Welcome to what's new in the .NET Aspire docs for April 2024. This article lists
 
 ### Updated articles
 
-- [.NET Aspire StackExchange Redis component](../caching/stackexchange-redis-component.md) - Correct xref and API for example usage
-- [.NET Aspire StackExchange Redis distributed caching component](../caching/stackexchange-redis-distributed-caching-component.md)
+- [.NET Aspire Stack Exchange Redis component](../caching/stackexchange-redis-component.md) - Correct xref and API for example usage
+- [.NET Aspire Stack Exchange Redis distributed caching component](../caching/stackexchange-redis-distributed-caching-component.md)
   - Correct xref and API for example usage
   - Fix link md
-- [.NET Aspire StackExchange Redis output caching component](../caching/stackexchange-redis-output-caching-component.md) - Correct xref and API for example usage
+- [.NET Aspire Stack Exchange Redis output caching component](../caching/stackexchange-redis-output-caching-component.md) - Correct xref and API for example usage
 
 ## Security
 

--- a/docs/whats-new/dotnet-docs-aspire-mod2.md
+++ b/docs/whats-new/dotnet-docs-aspire-mod2.md
@@ -145,9 +145,9 @@ Welcome to what's new in the .NET Aspire docs for May 2024. This article lists s
 
 ### Updated articles
 
-- [.NET Aspire StackExchange Redis component](../caching/stackexchange-redis-component.md) - Placeholder for .NET Aspire preview 7.
-- [.NET Aspire StackExchange Redis distributed caching component](../caching/stackexchange-redis-distributed-caching-component.md) - Placeholder for .NET Aspire preview 7.
-- [.NET Aspire StackExchange Redis output caching component](../caching/stackexchange-redis-output-caching-component.md) - Placeholder for .NET Aspire preview 7.
+- [.NET Aspire Stack Exchange Redis component](../caching/stackexchange-redis-component.md) - Placeholder for .NET Aspire preview 7.
+- [.NET Aspire Stack Exchange Redis distributed caching component](../caching/stackexchange-redis-distributed-caching-component.md) - Placeholder for .NET Aspire preview 7.
+- [.NET Aspire Stack Exchange Redis output caching component](../caching/stackexchange-redis-output-caching-component.md) - Placeholder for .NET Aspire preview 7.
 - [Tutorial: Implement caching with .NET Aspire components](../caching/caching-components.md) - Caching tutorial fixes
 
 ## Security


### PR DESCRIPTION
## Summary

- Add an overview of Stack Exchange Redis caching.
- Add TOC entry, and update Hub page.
- Fix brand name, should always have a space when referring to it by name (excluding NuGet package or namespace refs).

Fixes #1051


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/caching/caching-components-deployment.md](https://github.com/dotnet/docs-aspire/blob/a2c1fa1e7c2a6fad33bbb1bff4c3903bcac03eb9/docs/caching/caching-components-deployment.md) | [Tutorial: Deploy a .NET Aspire app with a Redis Cache to Azure](https://review.learn.microsoft.com/en-us/dotnet/aspire/caching/caching-components-deployment?branch=pr-en-us-1064) |
| [docs/caching/caching-components.md](https://github.com/dotnet/docs-aspire/blob/a2c1fa1e7c2a6fad33bbb1bff4c3903bcac03eb9/docs/caching/caching-components.md) | [Implement caching with .NET Aspire components](https://review.learn.microsoft.com/en-us/dotnet/aspire/caching/caching-components?branch=pr-en-us-1064) |
| [docs/caching/stackexchange-redis-caching-overview.md](https://github.com/dotnet/docs-aspire/blob/a2c1fa1e7c2a6fad33bbb1bff4c3903bcac03eb9/docs/caching/stackexchange-redis-caching-overview.md) | [Stack Exchange Redis caching overview](https://review.learn.microsoft.com/en-us/dotnet/aspire/caching/stackexchange-redis-caching-overview?branch=pr-en-us-1064) |
| [docs/caching/stackexchange-redis-component.md](https://github.com/dotnet/docs-aspire/blob/a2c1fa1e7c2a6fad33bbb1bff4c3903bcac03eb9/docs/caching/stackexchange-redis-component.md) | [docs/caching/stackexchange-redis-component](https://review.learn.microsoft.com/en-us/dotnet/aspire/caching/stackexchange-redis-component?branch=pr-en-us-1064) |
| [docs/caching/stackexchange-redis-distributed-caching-component.md](https://github.com/dotnet/docs-aspire/blob/a2c1fa1e7c2a6fad33bbb1bff4c3903bcac03eb9/docs/caching/stackexchange-redis-distributed-caching-component.md) | [.NET Aspire Stack Exchange Redis distributed caching component](https://review.learn.microsoft.com/en-us/dotnet/aspire/caching/stackexchange-redis-distributed-caching-component?branch=pr-en-us-1064) |
| [docs/caching/stackexchange-redis-output-caching-component.md](https://github.com/dotnet/docs-aspire/blob/a2c1fa1e7c2a6fad33bbb1bff4c3903bcac03eb9/docs/caching/stackexchange-redis-output-caching-component.md) | [.NET Aspire Stack Exchange Redis output caching Component](https://review.learn.microsoft.com/en-us/dotnet/aspire/caching/stackexchange-redis-output-caching-component?branch=pr-en-us-1064) |
| [docs/whats-new/dotnet-docs-aspire-mod1.md](https://github.com/dotnet/docs-aspire/blob/a2c1fa1e7c2a6fad33bbb1bff4c3903bcac03eb9/docs/whats-new/dotnet-docs-aspire-mod1.md) | [.NET Aspire docs: What's new for April 2024](https://review.learn.microsoft.com/en-us/dotnet/aspire/whats-new/dotnet-docs-aspire-mod1?branch=pr-en-us-1064) |
| [docs/whats-new/dotnet-docs-aspire-mod2.md](https://github.com/dotnet/docs-aspire/blob/a2c1fa1e7c2a6fad33bbb1bff4c3903bcac03eb9/docs/whats-new/dotnet-docs-aspire-mod2.md) | [docs/whats-new/dotnet-docs-aspire-mod2](https://review.learn.microsoft.com/en-us/dotnet/aspire/whats-new/dotnet-docs-aspire-mod2?branch=pr-en-us-1064) |


<!-- PREVIEW-TABLE-END -->