### PR TITLE
Add details about trusting dev-cert

### DIFF
--- a/docs/get-started/build-your-first-aspire-app.md
+++ b/docs/get-started/build-your-first-aspire-app.md
@@ -55,7 +55,7 @@ In Visual Studio, set the **AspireSample.AppHost** project as the startup projec
 :::zone-end
 :::zone pivot="vscode,dotnet-cli"
 
-If you haven't already trusted the localhost certificate, you may need to trust the certificate before running the app:
+If you haven't already trusted the ASP.NET Core localhost certificate, you will need to trust the certificate before running the app:
 
 ```dotnetcli
 dotnet dev-certs https --trust

--- a/docs/get-started/build-your-first-aspire-app.md
+++ b/docs/get-started/build-your-first-aspire-app.md
@@ -1,7 +1,7 @@
 ---
 title: Build your first .NET Aspire app
 description: Learn how to build your first .NET Aspire app using the .NET Aspire Started Application template.
-ms.date: 05/13/2024
+ms.date: 06/12/2024
 ms.topic: quickstart
 zone_pivot_groups: dev-environment
 ---
@@ -51,6 +51,17 @@ The sample app is now ready for testing. You want to verify the following:
 :::zone pivot="visual-studio"
 
 In Visual Studio, set the **AspireSample.AppHost** project as the startup project by right-clicking on the project in the **Solution Explorer** and selecting **Set as Startup Project**. Then, press <kbd>F5</kbd> to run the app.
+
+:::zone-end
+:::zone pivot="vscode,dotnet-cli"
+
+If you haven't already trusted the localhost certificate, you may need to trust the certificate before running the app:
+
+```dotnetcli
+dotnet dev-certs https --trust
+```
+
+For more information, see [Troubleshoot untrusted localhost certificate in .NET Aspire](../troubleshooting/untrusted-localhost-certificate.md). For in-depth details about troubleshooting localhost certificates on Linux, see [ASP.NET Core: GitHub repository issue #32842](https://github.com/dotnet/aspnetcore/issues/32842).
 
 :::zone-end
 :::zone pivot="vscode"

--- a/docs/troubleshooting/untrusted-localhost-certificate.md
+++ b/docs/troubleshooting/untrusted-localhost-certificate.md
@@ -42,3 +42,4 @@ For more troubleshooting, see [Troubleshoot certificate problems such as certifi
 - [Trust the ASP.NET Core HTTPS development certificate on Windows and macOS](/aspnet/core/security/enforcing-ssl#trust-the-aspnet-core-https-development-certificate-on-windows-and-macos)
 - [Trust HTTPS certificate on Linux](/aspnet/core/security/enforcing-ssl##trust-https-certificate-on-linux)
 - [.NET CLI: dotnet dev-certs](/dotnet/core/tools/dotnet-dev-certs)
+- [Trust localhost certificate on Linux](https://github.com/dotnet/aspnetcore/issues/32842)


### PR DESCRIPTION
## Summary

Add details about trusting dev-cert.

Fixes #1068


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/get-started/build-your-first-aspire-app.md](https://github.com/dotnet/docs-aspire/blob/df2a3155ddfb08a604ad6ff9665e9a46ef09a98d/docs/get-started/build-your-first-aspire-app.md) | [Quickstart: Build your first .NET Aspire app](https://review.learn.microsoft.com/en-us/dotnet/aspire/get-started/build-your-first-aspire-app?branch=pr-en-us-1087) |
| [docs/troubleshooting/untrusted-localhost-certificate.md](https://github.com/dotnet/docs-aspire/blob/df2a3155ddfb08a604ad6ff9665e9a46ef09a98d/docs/troubleshooting/untrusted-localhost-certificate.md) | [Troubleshoot untrusted localhost certificate in .NET Aspire](https://review.learn.microsoft.com/en-us/dotnet/aspire/troubleshooting/untrusted-localhost-certificate?branch=pr-en-us-1087) |

<!-- PREVIEW-TABLE-END -->