### PR TITLE
Fix OutputCache typos

### DIFF
--- a/docs/fundamentals/health-checks.md
+++ b/docs/fundamentals/health-checks.md
@@ -65,13 +65,13 @@ In the appropriate consuming app's entry point (usually the _:::no-loc text="Pro
 // Wherever your services are being registered.
 // Before the call to Build().
 builder.Services.AddRequestTimeouts();
-builder.Services.AddOutputCaching();
+builder.Services.AddOutputCache();
 
 var app = builder.Build();
 
 // Wherever your app has been built, before the call to Run().
 app.UseRequestTimeouts();
-app.UseOutputCaching();
+app.UseOutputCache();
 
 app.Run();
 ```


### PR DESCRIPTION
## Summary

Fix output caching typos in the docs.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/health-checks.md](https://github.com/dotnet/docs-aspire/blob/0efc352bf49c03866f7617fbcbc876f4101aa383/docs/fundamentals/health-checks.md) | [Health checks in .NET Aspire](https://review.learn.microsoft.com/en-us/dotnet/aspire/fundamentals/health-checks?branch=pr-en-us-1091) |

<!-- PREVIEW-TABLE-END -->