### PR TITLE
Matched the App host Redis reference to the consuming project

### DIFF
--- a/docs/caching/stackexchange-redis-distributed-caching-component.md
+++ b/docs/caching/stackexchange-redis-distributed-caching-component.md
@@ -60,7 +60,7 @@ builder.AddProject<Projects.ExampleProject>()
        .WithReference(redis)
 ```
 
-The <xref:Aspire.Hosting.ResourceBuilderExtensions.WithReference%2A> method configures a connection in the `ExampleProject` project named `redis`. In the _:::no-loc text="Program.cs":::_ file of `ExampleProject`, the Redis connection can be consumed using:
+The <xref:Aspire.Hosting.ResourceBuilderExtensions.WithReference%2A> method configures a connection in the `ExampleProject` project named `cache`. In the _:::no-loc text="Program.cs":::_ file of `ExampleProject`, the Redis connection can be consumed using:
 
 ```csharp
 builder.AddRedisDistributedCache("cache");

--- a/docs/caching/stackexchange-redis-distributed-caching-component.md
+++ b/docs/caching/stackexchange-redis-distributed-caching-component.md
@@ -54,7 +54,7 @@ public class ExampleService(IDistributedCache cache)
 ```csharp
 var builder = DistributedApplication.CreateBuilder(args);
 
-var redis = builder.AddRedis("redis");
+var redis = builder.AddRedis("cache");
 
 builder.AddProject<Projects.ExampleProject>()
        .WithReference(redis)


### PR DESCRIPTION
The instructions as provided don't work, because the reference used in App host didn't match that of the consumer. So I made them both "cache" for consistency.

## Summary

See above.  Just a very minor edit to the instructions for the Aspire Stack Exchange Redis distributed caching.

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/caching/stackexchange-redis-distributed-caching-component.md](https://github.com/dotnet/docs-aspire/blob/c30a42ea8a36fa58d188953eda21e2ea382999ef/docs/caching/stackexchange-redis-distributed-caching-component.md) | [.NET Aspire Stack Exchange Redis distributed caching component](https://review.learn.microsoft.com/en-us/dotnet/aspire/caching/stackexchange-redis-distributed-caching-component?branch=pr-en-us-1148) |


<!-- PREVIEW-TABLE-END -->