### PR TITLE
Add a manual merge from main to live.

### DIFF
--- a/.github/workflows/dispatch-merge-main-to-live.yml
+++ b/.github/workflows/dispatch-merge-main-to-live.yml
@@ -1,0 +1,51 @@
+name: go-live
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "The reason for running the workflow"
+        required: true
+        default: "Need to update live now, before daily scheduled run."
+
+jobs:
+  go-live:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: "Print manual run reason"
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          echo 'Reason: ${{ github.event.inputs.reason }}'
+
+      - name: Check out code
+        uses: actions/checkout@main
+
+      - name: Check for existing PR
+        id: exists
+        run: |
+          result=$(gh pr list --base live --head main --json number --jq '.[0].number' || echo "")
+          echo "PR_NUMBER=$result" >> $GITHUB_OUTPUT
+        shell: bash
+
+      - name: Create pull request
+        id: create
+        if: steps.exists.outputs.PR_NUMBER == ''
+        run: |
+          gh pr create \
+            --title "✅ Merge \`main\` into \`live\`" \
+            --body "🤖 Queue merge when ready..." \
+            --base live \
+            --head main
+          echo "CREATED=true" >> $GITHUB_OUTPUT
+
+      - name: Enable auto-merge for the pull request
+        if: steps.create.outputs.CREATED == 'true'
+        run: |
+          PR_NUMBER=$(gh pr list --base live --head main --json number --jq '.[0].number')
+          gh pr merge $PR_NUMBER --merge --auto


### PR DESCRIPTION
## Summary

Add a manual merge from main to live. If we need to merge from `main` to `live` outside of the scheduled time, then I can simply start this action to run.