### PR TITLE
Add two troubleshooters

### DIFF
--- a/docs/index.yml
+++ b/docs/index.yml
@@ -211,6 +211,12 @@ conceptualContent:
         - itemType: how-to-guide
           text: The specified name is already in use
           url: troubleshooting/name-is-already-in-use.md
+        - itemType: how-to-guide
+          text: Container runtime appears to be unhealthy
+          url: troubleshooting/container-runtime-unhealthy.md
+        - itemType: how-to-guide
+          text: The connection string is missing
+          url: troubleshooting/connection-string-missing.md
         - itemType: reference
           text: Ask questions on Discord
           url: https://aka.ms/aspire/discord

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -240,6 +240,10 @@ items:
         href: troubleshooting/unable-to-install-workload.md
       - name: The specified name is already in use
         href: troubleshooting/name-is-already-in-use.md
+      - name: Container runtime appears to be unhealthy
+        href: troubleshooting/container-runtime-unhealthy.md
+      - name: The connection string is missing
+        href: troubleshooting/connection-string-missing.md
       - name: .NET Aspire GitHub repository
         href: https://github.com/dotnet/aspire
       - name: Ask questions on Discord

--- a/docs/troubleshooting/connection-string-missing.md
+++ b/docs/troubleshooting/connection-string-missing.md
@@ -14,9 +14,9 @@ When your app accesses a service that needs one of the components in your app, i
 
 ## Possible solutions
 
-Verify that the name of the resource, for instance a database resource, is the same in the AppHost and the Service that fails. 
+Verify that the name of the resource, for instance a database resource, is the same in the AppHost and the Service that fails.
 
-For example, if the AppHost defines a PostgreSQL resource with the name db1 like this: 
+For example, if the AppHost defines a PostgreSQL resource with the name `db1` like this: 
 
 ```csharp
 var db1 = builder.AddPostgres("pg1").AddDatabase("db1"); 

--- a/docs/troubleshooting/connection-string-missing.md
+++ b/docs/troubleshooting/connection-string-missing.md
@@ -4,7 +4,7 @@ description: Learn how to troubleshoot the error "ConnectionString is missing" d
 ms.date: 07/03/2024
 ---
 
-# The specified name is already in use
+# Connection string is missing
 
 In .NET Aspire, code identifies resources with an arbitrary string, such as "database". Code that is consuming the resource elsewhere must use the same string or it will fail to correctly configure their relationships.
 

--- a/docs/troubleshooting/connection-string-missing.md
+++ b/docs/troubleshooting/connection-string-missing.md
@@ -6,7 +6,7 @@ ms.date: 07/03/2024
 
 # The specified name is already in use
 
-In an Aspire app, code identifies resources with an arbitrary string, such as "database". Code that is consuming the resource elsewhere must use the same string or it will fail.
+In .NET Aspire, code identifies resources with an arbitrary string, such as "database". Code that is consuming the resource elsewhere must use the same string or it will fail to correctly configure their relationships.
 
 ## Symptoms
 

--- a/docs/troubleshooting/connection-string-missing.md
+++ b/docs/troubleshooting/connection-string-missing.md
@@ -18,18 +18,18 @@ When your app accesses a service that needs one of the components in your app, i
 
 Verify that the name of the resource, for instance a database resource, is the same in the AppHost and the Service that fails.
 
-For example, if the AppHost defines a PostgreSQL resource with the name `db1` like this: 
+For example, if the AppHost defines a PostgreSQL resource with the name `db1` like this:
 
 ```csharp
-var db1 = builder.AddPostgres("pg1").AddDatabase("db1"); 
+var db1 = builder.AddPostgres("pg1").AddDatabase("db1");
 ```
- 
-Then the service needs to resolve the resource with the same name `db1`. 
+
+Then the service needs to resolve the resource with the same name `db1`.
 
 ```csharp
-var builder = WebApplication.CreateBuilder(args); 
+var builder = WebApplication.CreateBuilder(args);
 
-builder.AddNpgsqlDbContext<MyDb1Context>("db1"); 
+builder.AddNpgsqlDbContext<MyDb1Context>("db1");
 ```
 
 Any other value than the one provided in the AppHost will result in the exception message described above.

--- a/docs/troubleshooting/connection-string-missing.md
+++ b/docs/troubleshooting/connection-string-missing.md
@@ -6,6 +6,8 @@ ms.date: 07/03/2024
 
 # The specified name is already in use
 
+In an Aspire app, code identifies resources with an arbitrary string, such as "database". Code that is consuming the resource elsewhere must use the same string or it will fail.
+
 ## Symptoms
 
 When your app accesses a service that needs one of the components in your app, it may fail with an exception similar to the following:

--- a/docs/troubleshooting/connection-string-missing.md
+++ b/docs/troubleshooting/connection-string-missing.md
@@ -1,0 +1,33 @@
+---
+title: The connection string is missing
+description: Learn how to troubleshoot the error "ConnectionString is missing" during execution of your app.
+ms.date: 07/03/2024
+---
+
+# The specified name is already in use
+
+## Symptoms
+
+When your app accesses a service that needs one of the components in your app, it may fail with an exception similar to the following:
+
+> "InvalidOperationException: ConnectionString is missing."
+
+## Possible solutions
+
+Verify that the name of the resource, for instance a database resource, is the same in the AppHost and the Service that fails. 
+
+For example, if the AppHost defines a PostgreSQL resource with the name db1 like this: 
+
+```csharp
+var db1 = builder.AddPostgres("pg1").AddDatabase("db1"); 
+```
+ 
+Then the service needs to resolve the resource with the same name `db1`. 
+
+```csharp
+var builder = WebApplication.CreateBuilder(args); 
+
+builder.AddNpgsqlDbContext<MyDb1Context>("db1"); 
+```
+
+Any other value than the one provided in the AppHost will result in the exception message described above.

--- a/docs/troubleshooting/container-runtime-unhealthy.md
+++ b/docs/troubleshooting/container-runtime-unhealthy.md
@@ -6,9 +6,11 @@ ms.date: 07/03/2024
 
 # Container runtime appears to be unhealthy
 
+Aspire applications require Docker to be running and healthy. This topic describes a possible symptom you may see if Docker is not in a healthy state.
+
 ## Symptoms
 
-When starting the AppHost the dashboard doesn't show up and an exception stack trace similar to this example is displayed in the console: 
+When starting the AppHost the dashboard doesn't show up and an exception stack trace similar to this example is displayed in the console:
 
 ```Output
 info: Aspire.Hosting.DistributedApplication[0] 

--- a/docs/troubleshooting/container-runtime-unhealthy.md
+++ b/docs/troubleshooting/container-runtime-unhealthy.md
@@ -13,20 +13,20 @@ Aspire applications require Docker to be running and healthy. This topic describ
 When starting the AppHost the dashboard doesn't show up and an exception stack trace similar to this example is displayed in the console:
 
 ```Output
-info: Aspire.Hosting.DistributedApplication[0] 
-      Aspire version: 8.1.0-dev 
-info: Aspire.Hosting.DistributedApplication[0] 
-      Distributed application starting. 
-info: Aspire.Hosting.DistributedApplication[0] 
-      Application host directory is: D:\aspire\playground\PostgresEndToEnd\PostgresEndToEnd.AppHost 
-fail: Microsoft.Extensions.Hosting.Internal.Host[11] 
-      Hosting failed to start 
-      Aspire.Hosting.DistributedApplicationException: Container runtime 'docker' was found but appears to be unhealthy. The error from the container runtime check was error during connect: this error may indicate that the docker daemon is not running: Get "http://%2F%2F.%2Fpipe%2Fdocker_engine/v1.45/containers/json?limit=1": open //./pipe/docker_engine: The system cannot find the file specified.. 
+info: Aspire.Hosting.DistributedApplication[0]
+      Aspire version: 8.1.0-dev
+info: Aspire.Hosting.DistributedApplication[0]
+      Distributed application starting.
+info: Aspire.Hosting.DistributedApplication[0]
+      Application host directory is: D:\aspire\playground\PostgresEndToEnd\PostgresEndToEnd.AppHost
+fail: Microsoft.Extensions.Hosting.Internal.Host[11]
+      Hosting failed to start
+      Aspire.Hosting.DistributedApplicationException: Container runtime 'docker' was found but appears to be unhealthy. The error from the container runtime check was error during connect: this error may indicate that the docker daemon is not running: Get "http://%2F%2F.%2Fpipe%2Fdocker_engine/v1.45/containers/json?limit=1": open //./pipe/docker_engine: The system cannot find the file specified..
 ```
 
 ## Possible solutions
 
 Confirm that Docker is installed and running:
 
-- On Windows, check that in the system tray the Docker icon is present and marked as "Running". 
+- On Windows, check that in the system tray the Docker icon is present and marked as "Running".
 - On Linux, check that `docker ps -a` returns success.

--- a/docs/troubleshooting/container-runtime-unhealthy.md
+++ b/docs/troubleshooting/container-runtime-unhealthy.md
@@ -29,5 +29,3 @@ Confirm that Docker is installed and running.
 * On Windows, check that in the system tray the Docker icon is present and marked as "Running". 
 
 * On Linux, check that "docker ps -a" returns success.
-
-

--- a/docs/troubleshooting/container-runtime-unhealthy.md
+++ b/docs/troubleshooting/container-runtime-unhealthy.md
@@ -10,7 +10,7 @@ ms.date: 07/03/2024
 
 When starting the AppHost the dashboard doesn't show up and an exception stack trace similar to this example is displayed in the console: 
 
-```sh
+```Output
 info: Aspire.Hosting.DistributedApplication[0] 
       Aspire version: 8.1.0-dev 
 info: Aspire.Hosting.DistributedApplication[0] 
@@ -24,8 +24,7 @@ fail: Microsoft.Extensions.Hosting.Internal.Host[11]
 
 ## Possible solutions
 
-Confirm that Docker is installed and running. 
+Confirm that Docker is installed and running:
 
-* On Windows, check that in the system tray the Docker icon is present and marked as "Running". 
-
-* On Linux, check that "docker ps -a" returns success.
+- On Windows, check that in the system tray the Docker icon is present and marked as "Running". 
+- On Linux, check that `docker ps -a` returns success.

--- a/docs/troubleshooting/container-runtime-unhealthy.md
+++ b/docs/troubleshooting/container-runtime-unhealthy.md
@@ -1,0 +1,33 @@
+---
+title: Container runtime appears to be unhealthy
+description: Learn how to troubleshoot the error "Container runtime 'docker' was found but appears to be unhealthy" during execution of your app.
+ms.date: 07/03/2024
+---
+
+# Container runtime appears to be unhealthy
+
+## Symptoms
+
+When starting the AppHost the dashboard doesn't show up and an exception stack trace similar to this example is displayed in the console: 
+
+```sh
+info: Aspire.Hosting.DistributedApplication[0] 
+      Aspire version: 8.1.0-dev 
+info: Aspire.Hosting.DistributedApplication[0] 
+      Distributed application starting. 
+info: Aspire.Hosting.DistributedApplication[0] 
+      Application host directory is: D:\aspire\playground\PostgresEndToEnd\PostgresEndToEnd.AppHost 
+fail: Microsoft.Extensions.Hosting.Internal.Host[11] 
+      Hosting failed to start 
+      Aspire.Hosting.DistributedApplicationException: Container runtime 'docker' was found but appears to be unhealthy. The error from the container runtime check was error during connect: this error may indicate that the docker daemon is not running: Get "http://%2F%2F.%2Fpipe%2Fdocker_engine/v1.45/containers/json?limit=1": open //./pipe/docker_engine: The system cannot find the file specified.. 
+```
+
+## Possible solutions
+
+Confirm that Docker is installed and running. 
+
+* On Windows, check that in the system tray the Docker icon is present and marked as "Running". 
+
+* On Linux, check that "docker ps -a" returns success.
+
+

--- a/docs/troubleshooting/container-runtime-unhealthy.md
+++ b/docs/troubleshooting/container-runtime-unhealthy.md
@@ -6,7 +6,7 @@ ms.date: 07/03/2024
 
 # Container runtime appears to be unhealthy
 
-Aspire applications require Docker to be running and healthy. This topic describes a possible symptom you may see if Docker is not in a healthy state.
+.NET Aspire requires Docker (or Podman) to be running and healthy. This topic describes a possible symptom you may see if Docker isn’t in a healthy state.
 
 ## Symptoms
 


### PR DESCRIPTION
Going through the CSS troubleshooters, it will take time to migrate them into the docs. Starting with the two easiest.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/troubleshooting/connection-string-missing.md](https://github.com/dotnet/docs-aspire/blob/d2d94703062a08ff1aa32a0fd855370f48132255/docs/troubleshooting/connection-string-missing.md) | [Connection string is missing](https://review.learn.microsoft.com/en-us/dotnet/aspire/troubleshooting/connection-string-missing?branch=pr-en-us-1249) |
| [docs/troubleshooting/container-runtime-unhealthy.md](https://github.com/dotnet/docs-aspire/blob/d2d94703062a08ff1aa32a0fd855370f48132255/docs/troubleshooting/container-runtime-unhealthy.md) | [Container runtime appears to be unhealthy](https://review.learn.microsoft.com/en-us/dotnet/aspire/troubleshooting/container-runtime-unhealthy?branch=pr-en-us-1249) |


<!-- PREVIEW-TABLE-END -->