### PR TITLE
Update azd-dashboard.md file for fixing the doc bug as received the suggestion .

### DIFF
--- a/docs/deployment/azure/includes/azd-dashboard.md
+++ b/docs/deployment/azure/includes/azd-dashboard.md
@@ -1,12 +1,8 @@
 ## Deploy the .NET Aspire Dashboard
 
-You can deploy the .NET Aspire dashboard as part of your hosted app. This feature is currently in alpha support, so you must enable the `alpha.aspire.dashboard` [feature flag](/azure/developer/azure-developer-cli/feature-versioning). When enabled, the `azd` output logs print an additional URL to the deployed dashboard.
+You can deploy the .NET Aspire dashboard as part of your hosted app. This feature is now fully supported. When deploying, the azd output logs print an additional URL to the deployed dashboard.
 
-```azdeveloper
-azd config set alpha.aspire.dashboard on
-```
-
-You can also run `azd monitor` to automatically launch the dashboard.
+You can run `azd monitor` to automatically launch the dashboard.
 
 ```azdeveloper
 azd monitor


### PR DESCRIPTION
Updated the file azd-dashboard.ms as aspire.dashboard is no longer alpha now. Thanks

## Summary

Analyzed the open GitHub Doc bug: 12287: [https://github.com/MicrosoftDocs/azure-docs/issues/122827]

aspire.dashboard is no longer alpha now as per the merged commits [https://github.com/Azure/azure-dev/pull/3925]

Fixes #Issue_Number (if available)

12287