### PR TITLE
Update quest-config.json

### DIFF
--- a/quest-config.json
+++ b/quest-config.json
@@ -32,5 +32,11 @@
             "ParentNodeId": 227484
         }
     ],
-     "DefaultParentNode": 227485
+    "DefaultParentNode": 227485,
+    "WorkItemTags": [
+        {
+            "Label": ":label: content-curation",
+            "Tag": "content-curation"
+        }
+    ]
 }


### PR DESCRIPTION
- Add the content curation tag for quest items.

The actual github label used to trigger the quest tag is something you can change. I used `🏷️ content-curation` but feel free to edit this PR to change it to what you want.

You'll need to add this label to this repo and then use it for curation items.