### PR TITLE
Remove explicit checkout of SHA, as it's not needed

### DIFF
--- a/.github/workflows/check-for-build-warnings.yml
+++ b/.github/workflows/check-for-build-warnings.yml
@@ -21,10 +21,6 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-
       - uses: dotnet/docs-tools/actions/status-checker@cf581edfb9f8bbccc3f0476ce1b8369689fb0290 # main
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Remove explicit checkout of SHA, as it's not needed.

Fixes:
- https://github.com/ossf/scorecard/blob/main/docs/checks.md#dangerous-workflow

Related to #1345