### PR TITLE
Adjust code snippets

### DIFF
--- a/docs/database/seed-database-data.md
+++ b/docs/database/seed-database-data.md
@@ -87,7 +87,7 @@ The following examples demonstrate how to seed data using SQL scripts and config
 
 The configuration code in the **.AppHost** _:::no-loc text="Program.cs":::_ file mounts the required database files and folders and configures an entrypoint so that they run during startup.
 
-:::code source="~/aspire-samples/samples/DatabaseContainers/DatabaseContainers.AppHost/Program.cs" range="25-35" :::
+:::code source="~/aspire-samples/samples/DatabaseContainers/DatabaseContainers.AppHost/Program.cs" range="26-37" :::
 
 The _entrypoint.sh_ script lives in the mounted `./sqlserverconfig` project folder and runs when the container starts. The script launches SQL Server and checks that it's running.
 
@@ -101,7 +101,7 @@ The _init.sql_ SQL script that lives in the mounted `../DatabaseContainers.ApiSe
 
 Configuration code in the **.AppHost** project:
 
-:::code source="~/aspire-samples/samples/DatabaseContainers/DatabaseContainers.AppHost/Program.cs" range="3-12" :::
+:::code source="~/aspire-samples/samples/DatabaseContainers/DatabaseContainers.AppHost/Program.cs" range="3-14" :::
 
 Corresponding SQL script included in the app:
 
@@ -111,7 +111,7 @@ Corresponding SQL script included in the app:
 
 Configuration code in the **.AppHost** project:
 
-:::code source="~/aspire-samples/samples/DatabaseContainers/DatabaseContainers.AppHost/Program.cs" range="14-23" :::
+:::code source="~/aspire-samples/samples/DatabaseContainers/DatabaseContainers.AppHost/Program.cs" range="15-25" :::
 
 Corresponding SQL script included in the app:
 


### PR DESCRIPTION
## Summary

Adjusting the code snippets display in the section "Database seeding examples". Starting when `mysql`, `sqlserver` and `postgres` really start, and ending after the `AddDatabase()` command.



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/database/seed-database-data.md](https://github.com/dotnet/docs-aspire/blob/0c9ff1333270454dd5052eddc79c8962aad45c6b/docs/database/seed-database-data.md) | [docs/database/seed-database-data](https://review.learn.microsoft.com/en-us/dotnet/aspire/database/seed-database-data?branch=pr-en-us-1373) |

<!-- PREVIEW-TABLE-END -->