### PR TITLE
Fix nats link

### DIFF
--- a/docs/messaging/nats-component.md
+++ b/docs/messaging/nats-component.md
@@ -172,5 +172,5 @@ The .NET Aspire NATS component emits the following tracing activities:
 
 ## See also
 
-- [NATS.Net quickstart](https://nats-io.github.io/nats.net.v2/documentation/intro.html?tabs=core-nats)
+- [NATS.Net quickstart](https://nats-io.github.io/nats.net/documentation/intro.html?tabs=core-nats)
 - [NATS component README](https://github.com/dotnet/aspire/tree/main/src/Components/README.md)


### PR DESCRIPTION
Contributes to dotnet/docs#41277.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/messaging/nats-component.md](https://github.com/dotnet/docs-aspire/blob/6f2ddf9f96eedd4d02d936aafd5164ea466d2e2b/docs/messaging/nats-component.md) | [docs/messaging/nats-component](https://review.learn.microsoft.com/en-us/dotnet/aspire/messaging/nats-component?branch=pr-en-us-1385) |

<!-- PREVIEW-TABLE-END -->