### PR TITLE
Caching documentation fixes

### DIFF
--- a/docs/caching/stackexchange-redis-component.md
+++ b/docs/caching/stackexchange-redis-component.md
@@ -54,13 +54,13 @@ public class ExampleService(IConnectionMultiplexer connectionMultiplexer)
 ```csharp
 var builder = DistributedApplication.CreateBuilder(args);
 
-var redis = builder.AddRedis("redis");
+var redis = builder.AddRedis("cache");
 
 builder.AddProject<Projects.ExampleProject>()
        .WithReference(redis)
 ```
 
-The <xref:Aspire.Hosting.ResourceBuilderExtensions.WithReference%2A> method configures a connection in the `ExampleProject` project named `redis`. In the _:::no-loc text="Program.cs":::_ file of `ExampleProject`, the Redis connection can be consumed using:
+The <xref:Aspire.Hosting.ResourceBuilderExtensions.WithReference%2A> method configures a connection in the `ExampleProject` project named `cache`. In the _:::no-loc text="Program.cs":::_ file of `ExampleProject`, the Redis connection can be consumed using:
 
 ```csharp
 builder.AddRedis("cache");

--- a/docs/caching/stackexchange-redis-output-caching-component.md
+++ b/docs/caching/stackexchange-redis-output-caching-component.md
@@ -61,13 +61,13 @@ For apps with controllers, apply the `[OutputCache]` attribute to the action met
 ```csharp
 var builder = DistributedApplication.CreateBuilder(args);
 
-var redis = builder.AddRedis("redis");
+var redis = builder.AddRedis("messaging");
 
 var basket = builder.AddProject<Projects.ExampleProject>()
                     .WithReference(redis)
 ```
 
-The <xref:Aspire.Hosting.ResourceBuilderExtensions.WithReference%2A> method configures a connection in the `ExampleProject` project named `redis`. In the _:::no-loc text="Program.cs":::_ file of `ExampleProject`, the Redis connection can be consumed using:
+The <xref:Aspire.Hosting.ResourceBuilderExtensions.WithReference%2A> method configures a connection in the `ExampleProject` project named `messaging`. In the _:::no-loc text="Program.cs":::_ file of `ExampleProject`, the Redis connection can be consumed using:
 
 ```csharp
 builder.AddRedisOutputCache("messaging");


### PR DESCRIPTION
## Summary

Made the App host usage consistent with the consuming project references, in both the redis component and redis output caching component docs. Otherwise the instructions as previously provided will not work.

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/caching/stackexchange-redis-component.md](https://github.com/dotnet/docs-aspire/blob/2068061f2b281f3adddc8aa784cb18dadd3ed63f/docs/caching/stackexchange-redis-component.md) | [docs/caching/stackexchange-redis-component](https://review.learn.microsoft.com/en-us/dotnet/aspire/caching/stackexchange-redis-component?branch=pr-en-us-1386) |
| [docs/caching/stackexchange-redis-output-caching-component.md](https://github.com/dotnet/docs-aspire/blob/2068061f2b281f3adddc8aa784cb18dadd3ed63f/docs/caching/stackexchange-redis-output-caching-component.md) | [docs/caching/stackexchange-redis-output-caching-component](https://review.learn.microsoft.com/en-us/dotnet/aspire/caching/stackexchange-redis-output-caching-component?branch=pr-en-us-1386) |

<!-- PREVIEW-TABLE-END -->