### PR TITLE
Update build-aspire-apps-with-python.md

### DIFF
--- a/docs/get-started/build-aspire-apps-with-python.md
+++ b/docs/get-started/build-aspire-apps-with-python.md
@@ -163,7 +163,7 @@ Update the app host _Program.cs_ file to include the Python project, by calling 
 Now that you've added the Python hosting package, updated the app host _Program.cs_ file, and created a Python project, you can run the app host:
 
 ```dotnetcli
-dotnet run --project PythonSample.AppHost/PythonSample.AppHost.csproj
+dotnet run --project ../PythonSample.AppHost/PythonSample.AppHost.csproj
 ```
 
 Launch the dashboard by clicking the link in the console output. The dashboard should display the Python project as a resource.
@@ -199,7 +199,7 @@ Update the app host project's _launchSettings.json_ file to include the `ASPIRE_
 The `ASPIRE_ALLOW_UNSECURED_TRANSPORT` variable is required because when running locally the OpenTelemetry client in Python rejects the local development certificate. Launch the _app host_ again:
 
 ```dotnetcli
-dotnet run --project PythonSample.AppHost/PythonSample.AppHost.csproj
+dotnet run --project ../PythonSample.AppHost/PythonSample.AppHost.csproj
 ```
 
 Once the app host has launched navigate to the dashboard and note that in addition to console log output, structured logging is also being routed through to the dashboard.


### PR DESCRIPTION
## Summary

Updated the two C# project references to have one level of indirection to keep with the `hello-python` working directory context of the tutorial, to stay consistent with the first use of that strategy (vs `cd ..` to the parent first). As-is, the two subsequent `dotnet run` commands cannot find the app host project, given the pwd.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/get-started/build-aspire-apps-with-python.md](https://github.com/dotnet/docs-aspire/blob/8159bb5d75321195bedb41478ce005984c68dfc3/docs/get-started/build-aspire-apps-with-python.md) | [docs/get-started/build-aspire-apps-with-python](https://review.learn.microsoft.com/en-us/dotnet/aspire/get-started/build-aspire-apps-with-python?branch=pr-en-us-1420) |

<!-- PREVIEW-TABLE-END -->