### PR TITLE
Fix code section closing tag

### DIFF
--- a/docs/database/mongodb-component.md
+++ b/docs/database/mongodb-component.md
@@ -145,6 +145,7 @@ The following example shows an _:::no-loc text="appsettings.json":::_ file that 
       },
     }
   }
+```
 
 ### Use inline configurations
 


### PR DESCRIPTION
## Summary

Close code sections to prevent the sections mixing


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/database/mongodb-component.md](https://github.com/dotnet/docs-aspire/blob/210a4c34009457730374f8d8cb59782be10a23e7/docs/database/mongodb-component.md) | [docs/database/mongodb-component](https://review.learn.microsoft.com/en-us/dotnet/aspire/database/mongodb-component?branch=pr-en-us-1439) |

<!-- PREVIEW-TABLE-END -->