### PR TITLE
Change target for code sample

### DIFF
--- a/docs/database/seed-database-data.md
+++ b/docs/database/seed-database-data.md
@@ -126,7 +126,7 @@ You can also seed data in .NET Aspire projects using Entity Framework Core by ex
 > [!IMPORTANT]
 > These types of configurations should only be done during development, so make sure to add a conditional that checks your current environment context.
 
-Add the following code to the _:::no-loc text="Program.cs":::_ file of your **.AppHost** project.
+Add the following code to the _:::no-loc text="Program.cs":::_ file of your **API Service** project.
 
 ### [SQL Server](#tab/sql-server)
 


### PR DESCRIPTION
## Summary

Current version says that code should be added to the AppHost project.
`builder` there is `IDistributedApplicationBuilder` and has no such extensions in `Aspire.Npgsql.EntityFrameworkCore.PostgreSQL` package. There is also `.MapDefaultEndpoints()` call which is from `Aspire.ServiceDefaults` projects which is referenced by all API Service projects.

![image](https://github.com/user-attachments/assets/1546017d-5481-4258-8cdc-c8d1240afc32)

Not sure about the best project name though.
https://learn.microsoft.com/en-us/dotnet/aspire/database/postgresql-entity-framework-component?tabs=dotnet-cli
![image](https://github.com/user-attachments/assets/d00a554e-6488-4506-81d8-9d4000017dcd)
EF Core component says `consuming client project` instead the `API service project` I have used

