### PR TITLE
Update MailKitClientSettings.cs

### DIFF
--- a/docs/extensibility/snippets/MailDevResourceAndComponent/MailKit.Client/MailKitClientSettings.cs
+++ b/docs/extensibility/snippets/MailDevResourceAndComponent/MailKit.Client/MailKitClientSettings.cs
@@ -72,7 +72,7 @@ public sealed class MailKitClientSettings
                         """);
             }
 
-            if (Uri.TryCreate(endpoint.ToString(), UriKind.Absolute, out var uri) is false)
+            if (Uri.TryCreate(endpoint.ToString(), UriKind.Absolute, out uri) is false)
             {
                 throw new InvalidOperationException($"""
                         The 'ConnectionStrings:<connectionName>' (or 'Endpoint' key in


### PR DESCRIPTION
I removed the duplicate declaration of the `uri` variable.  Which prevents:
```
A local or parameter named 'uri' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
```


