### PR TITLE
Update custom-component.md

### DIFF
--- a/docs/extensibility/custom-component.md
+++ b/docs/extensibility/custom-component.md
@@ -155,6 +155,12 @@ With the component library created, you can now update the Newsletter service to
 dotnet add ./MailDevResource.NewsletterService/MailDevResource.NewsletterService.csproj reference MailKit.Client/MailKit.Client.csproj
 ```
 
+Next, add a reference to the `ServiceDefaults` project:
+
+```dotnetcli
+dotnet add ./MailDevResource.NewsletterService/MailDevResource.NewsletterService.csproj reference MailDevResource.ServiceDefaults/MailDevResource.ServiceDefaults.csproj
+```
+
 The final step is to replace the existing _:::no-loc text="Program.cs":::_ file in the `MailDevResource.NewsletterService` project with the following C# code:
 
 :::code source="snippets/MailDevResourceAndComponent/MailDevResource.NewsletterService/Program.cs":::


### PR DESCRIPTION
I added a reference to `ServiceDefaults` which was missing




<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/extensibility/custom-component.md](https://github.com/dotnet/docs-aspire/blob/8413882300e42799b90e3492796c3df569ac61c8/docs/extensibility/custom-component.md) | [docs/extensibility/custom-component](https://review.learn.microsoft.com/en-us/dotnet/aspire/extensibility/custom-component?branch=pr-en-us-1550) |


<!-- PREVIEW-TABLE-END -->