### PR TITLE
Update MailKitClientSettings.cs

### DIFF
--- a/docs/extensibility/snippets/MailDevResourceWithCredentials/MailKit.Client/MailKitClientSettings.cs
+++ b/docs/extensibility/snippets/MailDevResourceWithCredentials/MailKit.Client/MailKitClientSettings.cs
@@ -82,7 +82,7 @@ public sealed class MailKitClientSettings
                         """);
             }
 
-            if (Uri.TryCreate(endpoint.ToString(), UriKind.Absolute, out var uri) is false)
+            if (Uri.TryCreate(endpoint.ToString(), UriKind.Absolute, out uri) is false)
             {
                 throw new InvalidOperationException($"""
                         The 'ConnectionStrings:<connectionName>' (or 'Endpoint' key in


### PR DESCRIPTION
I removed the duplicate declaration of the `uri` variable. Which prevents:

`A local or parameter named 'uri' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter`