### PR TITLE
Switch order of approve and auto-merge

### DIFF
--- a/.github/policies/auto-merge.yml
+++ b/.github/policies/auto-merge.yml
@@ -17,10 +17,10 @@ configuration:
           - targetsBranch:
               branch: main
         then:
-          - enableAutoMerge:
-              mergeMethod: Squash
           - approvePullRequest:
               comment: "Approved; this PR will merge when all status checks pass."
+          - enableAutoMerge:
+              mergeMethod: Squash
 
       - description: Auto-merge PRs to live labeled with 'auto-merge'
         triggerOnOwnActions: true


### PR DESCRIPTION
PRs from dependabot aren't getting auto-approved.