### PR TITLE
Use correct method name in ServiceBus

### DIFF
--- a/docs/messaging/azure-service-bus-integration.md
+++ b/docs/messaging/azure-service-bus-integration.md
@@ -113,14 +113,14 @@ The Service Bus integration supports <xref:Microsoft.Extensions.Configuration?di
 }
 ```
 
-If you have set up your configurations in the `Aspire:Azure:Messaging:ServiceBus` section of your _:::no-loc text="appsettings.json":::_ file you can just call the method `AddAzureServiceBus` without passing any parameters.
+If you have set up your configurations in the `Aspire:Azure:Messaging:ServiceBus` section of your _:::no-loc text="appsettings.json":::_ file you can just call the method `AddAzureServiceBusClient` without passing any parameters.
 
 ### Use inline delegates
 
 You can also pass the `Action<AzureMessagingServiceBusSettings>` delegate to set up some or all the options inline, for example to set the `FullyQualifiedNamespace`:
 
 ```csharp
-builder.AddAzureServiceBus(
+builder.AddAzureServiceBusClient(
     "messaging",
     static settings => settings.FullyQualifiedNamespace = "YOUR_SERVICE_BUS_NAMESPACE");
 ```
@@ -128,7 +128,7 @@ builder.AddAzureServiceBus(
 You can also set up the [ServiceBusClientOptions](/dotnet/api/azure.messaging.servicebus.servicebusclientoptions) using `Action<IAzureClientBuilder<ServiceBusClient, ServiceBusClientOptions>>` delegate, the second parameter of the `AddAzureServiceBus` method. For example to set the `ServiceBusClient` ID to identify the client:
 
 ```csharp
-builder.AddAzureServiceBus(
+builder.AddAzureServiceBusClient(
     "messaging",
     static clientBuilder =>
         clientBuilder.ConfigureOptions(

--- a/docs/messaging/azure-service-bus-integration.md
+++ b/docs/messaging/azure-service-bus-integration.md
@@ -135,33 +135,6 @@ builder.AddAzureServiceBusClient(
             static options => options.Identifier = "CLIENT_ID"));
 ```
 
-### Named instances
-
-If you want to add more than one [ServiceBusClient](/dotnet/api/azure.messaging.servicebus.servicebusclient) you can use named instances. Load the named configuration section from the JSON config by calling the `AddAzureServiceBus` method and passing in the `INSTANCE_NAME`.
-
-```csharp
-builder.AddAzureServiceBus("INSTANCE_NAME");
-```
-
-The corresponding configuration JSON is defined as follows:
-
-```json
-{
-  "Aspire": {
-    "Azure": {
-      "Messaging": {
-        "INSTANCE_NAME": {
-          "FullyQualifiedNamespace": "YOUR_SERVICE_BUS_NAMESPACE",
-          "ClientOptions": {
-            "Identifier": "CLIENT_ID"
-          }
-        }
-      }
-    }
-  }
-}
-```
-
 ### Configuration options
 
 The following configurable options are exposed through the <xref:Aspire.Azure.Messaging.ServiceBus.AzureMessagingServiceBusSettings> class:

--- a/docs/security/azure-security-key-vault-integration.md
+++ b/docs/security/azure-security-key-vault-integration.md
@@ -155,37 +155,6 @@ builder.AddAzureKeyVaultSecrets(
             static options => options.DisableChallengeResourceVerification = true))
 ```
 
-### Named instances
-
-If you want to add more than one `SecretClient` you can use named instances. Load the named configuration section from the json config by calling the `AddAzureKeyVaultSecrets` method and passing in the `INSTANCE_NAME`.
-
-```csharp
-builder.AddAzureKeyVaultSecrets("INSTANCE_NAME");
-```
-
-The corresponding configuration JSON is defined as follows:
-
-```json
-{
-  "Aspire": {
-    "Azure": {
-      "Security": {
-        "KeyVault": {
-          "INSTANCE_NAME": {
-            "VaultUri": "YOUR_VAULT_URI",
-            "DisableHealthChecks": false,
-            "DisableTracing": true,
-            "ClientOptions": {
-              "DisableChallengeResourceVerification": true
-            }
-          }
-        }
-      }
-    }
-  }
-}
-```
-
 ### Configuration options
 
 The following configurable options are exposed through the <xref:Aspire.Azure.Security.KeyVault.AzureSecurityKeyVaultSettings> class:

--- a/docs/storage/azure-storage-tables-integration.md
+++ b/docs/storage/azure-storage-tables-integration.md
@@ -137,36 +137,6 @@ builder.AddAzureTableClient(
             static options => options.EnableTenantDiscovery = true));
 ```
 
-### Named instances
-
-If you want to add more than one <xref:Azure.Data.Tables.TableServiceClient> you can use named instances. Load the named configuration section from the json config by calling the `AddAzureTableClient` method and passing in the `INSTANCE_NAME`.
-
-```csharp
-builder.AddAzureTableClient("INSTANCE_NAME");
-```
-
-The corresponding configuration JSON is defined as follows:
-
-```json
-{
-  "Aspire":{
-    "Azure": {
-      "Data": {
-        "Tables": {
-          "INSTANCE_NAME": {
-            "ServiceUri": "YOUR_URI",
-            "DisableHealthChecks": true,
-            "ClientOptions": {
-              "EnableTenantDiscovery": true
-            }
-          }
-        }
-      }
-    }
-  }
-}
-```
-
 ### Configuration options
 
 The following configurable options are exposed through the <xref:Aspire.Azure.Data.Tables.AzureDataTablesSettings> class:


### PR DESCRIPTION
## Summary

We need to use `Client` on these method calls.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/messaging/azure-service-bus-integration.md](https://github.com/dotnet/docs-aspire/blob/02a02ba421c92a62a48f286d9fa5749d84514fe8/docs/messaging/azure-service-bus-integration.md) | [docs/messaging/azure-service-bus-integration](https://review.learn.microsoft.com/en-us/dotnet/aspire/messaging/azure-service-bus-integration?branch=pr-en-us-1757) |
| [docs/security/azure-security-key-vault-integration.md](https://github.com/dotnet/docs-aspire/blob/02a02ba421c92a62a48f286d9fa5749d84514fe8/docs/security/azure-security-key-vault-integration.md) | [docs/security/azure-security-key-vault-integration](https://review.learn.microsoft.com/en-us/dotnet/aspire/security/azure-security-key-vault-integration?branch=pr-en-us-1757) |
| [docs/storage/azure-storage-tables-integration.md](https://github.com/dotnet/docs-aspire/blob/02a02ba421c92a62a48f286d9fa5749d84514fe8/docs/storage/azure-storage-tables-integration.md) | [docs/storage/azure-storage-tables-integration](https://review.learn.microsoft.com/en-us/dotnet/aspire/storage/azure-storage-tables-integration?branch=pr-en-us-1757) |


<!-- PREVIEW-TABLE-END -->