### PR TITLE
Fix typos in Service Bus integration docs

### DIFF
--- a/docs/messaging/azure-service-bus-integration.md
+++ b/docs/messaging/azure-service-bus-integration.md
@@ -120,7 +120,7 @@ If you have set up your configurations in the `Aspire:Azure:Messaging:ServiceBus
 You can also pass the `Action<AzureMessagingServiceBusSettings>` delegate to set up some or all the options inline, for example to set the `FullyQualifiedNamespace`:
 
 ```csharp
-builder.AddAzureServiceBus(
+builder.AddAzureServiceBusClient(
     "messaging",
     static settings => settings.FullyQualifiedNamespace = "YOUR_SERVICE_BUS_NAMESPACE");
 ```
@@ -128,7 +128,7 @@ builder.AddAzureServiceBus(
 You can also set up the [ServiceBusClientOptions](/dotnet/api/azure.messaging.servicebus.servicebusclientoptions) using `Action<IAzureClientBuilder<ServiceBusClient, ServiceBusClientOptions>>` delegate, the second parameter of the `AddAzureServiceBus` method. For example to set the `ServiceBusClient` ID to identify the client:
 
 ```csharp
-builder.AddAzureServiceBus(
+builder.AddAzureServiceBusClient(
     "messaging",
     static clientBuilder =>
         clientBuilder.ConfigureOptions(
@@ -140,7 +140,7 @@ builder.AddAzureServiceBus(
 If you want to add more than one [ServiceBusClient](/dotnet/api/azure.messaging.servicebus.servicebusclient) you can use named instances. Load the named configuration section from the JSON config by calling the `AddAzureServiceBus` method and passing in the `INSTANCE_NAME`.
 
 ```csharp
-builder.AddAzureServiceBus("INSTANCE_NAME");
+builder.AddAzureServiceBusClient("INSTANCE_NAME");
 ```
 
 The corresponding configuration JSON is defined as follows:


### PR DESCRIPTION
Realized these were incorrect after consulting @eerhardt while doing some app building...

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/messaging/azure-service-bus-integration.md](https://github.com/dotnet/docs-aspire/blob/889381c1356c67781e3e46427832cbaa123390f9/docs/messaging/azure-service-bus-integration.md) | [docs/messaging/azure-service-bus-integration](https://review.learn.microsoft.com/en-us/dotnet/aspire/messaging/azure-service-bus-integration?branch=pr-en-us-1758) |

<!-- PREVIEW-TABLE-END -->