### PR TITLE
Add docs about NATS password protection

### DIFF
--- a/docs/messaging/includes/nats-explicit-username-password.md
+++ b/docs/messaging/includes/nats-explicit-username-password.md
@@ -1,0 +1,13 @@
+When you want to explicitly provide the username and password, you can provide those as parameters. Consider the following alternative example:
+
+```csharp
+var username = builder.AddParameter("username", secret: true);
+var password = builder.AddParameter("password", secret: true);
+
+var nats = builder.AddNats("nats", userName: username, password: password);
+
+var exampleProject = builder.AddProject<Projects.ExampleProject>()
+                            .WithReference(nats);
+```
+
+For more information, see [External parameters](../../fundamentals/external-parameters.md).

--- a/docs/messaging/nats-integration.md
+++ b/docs/messaging/nats-integration.md
@@ -47,6 +47,8 @@ builder.AddProject<Projects.ExampleProject>()
 // After adding all resources, run the app...
 ```
 
+[!INCLUDE [nats-explicit-username-password](includes/nats-explicit-username-password.md)]
+
 When .NET Aspire adds a container image to the app host, as shown in the preceding example with the `docker.io/library/nats` image, it creates a new NATS server instance on your local machine. A reference to your NATS server (the `nats` variable) is added to the `ExampleProject`.
 
 The <xref:Aspire.Hosting.ResourceBuilderExtensions.WithReference%2A> method configures a connection in the `ExampleProject` named `"nats"`. For more information, see [Container resource lifecycle](../fundamentals/app-host-overview.md#container-resource-lifecycle).


### PR DESCRIPTION
## Summary

Adds docs for password protection for NATS. This is for the following (not merged yet) PR: https://github.com/dotnet/aspire/pull/6259


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/messaging/nats-integration.md](https://github.com/dotnet/docs-aspire/blob/dcc41cb5d52a646124fbc6d2fc4c7bd29a25e4ff/docs/messaging/nats-integration.md) | [.NET Aspire NATS integration](https://review.learn.microsoft.com/en-us/dotnet/aspire/messaging/nats-integration?branch=pr-en-us-1817) |

<!-- PREVIEW-TABLE-END -->