### PR TITLE
Fix Kafka integration documentation

### DIFF
--- a/docs/messaging/kafka-integration.md
+++ b/docs/messaging/kafka-integration.md
@@ -290,8 +290,8 @@ builder.AddKafkaProducer<string, MyMessage>(
 
 When registering producers and consumers, if you need to access a service registered in the DI container, you can pass an `Action<IServiceProvider, ProducerBuilder<TKey, TValue>>` or `Action<IServiceProvider, ConsumerBuilder<TKey, TValue>>` respectively:
 
-- <xref:Microsoft.Extensions.Hosting.AspireKafkaProducerExtensions.AddKafkaProducer<TKey,TValue>(IHostApplicationBuilder, String, Action<KafkaProducerSettings>, Action<IServiceProvider,ProducerBuilder<TKey,TValue>>)>
-- <xref:Microsoft.Extensions.Hosting.AspireKafkaConsumerExtensions.AddKafkaConsumer<TKey,TValue>(IHostApplicationBuilder, String, Action<KafkaConsumerSettings>, Action<IServiceProvider,ConsumerBuilder<TKey,TValue>>)>
+- <xref:Microsoft.Extensions.Hosting.AspireKafkaProducerExtensions.AddKafkaProducer``2(Microsoft.Extensions.Hosting.IHostApplicationBuilder,System.String,System.Action{System.IServiceProvider,Confluent.Kafka.ProducerBuilder{``0,``1}})>
+- <xref:Microsoft.Extensions.Hosting.AspireKafkaConsumerExtensions.AddKafkaConsumer``2(Microsoft.Extensions.Hosting.IHostApplicationBuilder,System.String,System.Action{System.IServiceProvider,Confluent.Kafka.ConsumerBuilder{``0,``1}})>
 
 Consider the following producer registration example:
 

--- a/docs/messaging/kafka-integration.md
+++ b/docs/messaging/kafka-integration.md
@@ -288,6 +288,18 @@ builder.AddKafkaProducer<string, MyMessage>(
     })
 ```
 
+In case you need a service registered in the DI container, you can pass an `Action<IServiceProvider, ProducerBuilder<TKey, TValue>>` (or `Action<IServiceProvider, ConsumerBuilder<TKey, TValue>>`) too:
+
+```csharp
+builder.AddKafkaProducer<string, MyMessage>(
+    "messaging",
+    static (serviceProvider, producerBuilder) => 
+    {
+        var messageSerializer = serviceProvider.GetRequiredServices<MyMessageSerializer>();
+        producerBuilder.SetValueSerializer(messageSerializer);
+    })
+```
+
 For more information, see [`ProducerBuilder<TKey, TValue>`](https://docs.confluent.io/platform/current/clients/confluent-kafka-dotnet/_site/api/Confluent.Kafka.ProducerBuilder-2.html) and [`ConsumerBuilder<TKey, TValue>`](https://docs.confluent.io/platform/current/clients/confluent-kafka-dotnet/_site/api/Confluent.Kafka.ConsumerBuilder-2.html) API documentation.
 
 ### Client integration health checks
@@ -312,9 +324,7 @@ The .NET Aspire Apache Kafka integration uses the following log categories:
 
 #### Tracing
 
-The .NET Aspire Apache Kafka integration emits the following tracing activities using OpenTelemetry:
-
-- `Aspire.Confluent.Kafka`
+The .NET Aspire Apache Kafka integration dos not emit distributed traces.
 
 #### Metrics
 

--- a/docs/messaging/kafka-integration.md
+++ b/docs/messaging/kafka-integration.md
@@ -288,7 +288,12 @@ builder.AddKafkaProducer<string, MyMessage>(
     })
 ```
 
-In case you need a service registered in the DI container, you can pass an `Action<IServiceProvider, ProducerBuilder<TKey, TValue>>` (or `Action<IServiceProvider, ConsumerBuilder<TKey, TValue>>`) too:
+When registering producers and consumers, if you need to access a service registered in the DI container, you can pass an `Action<IServiceProvider, ProducerBuilder<TKey, TValue>>` or `Action<IServiceProvider, ConsumerBuilder<TKey, TValue>>` respectively:
+
+- <xref:Microsoft.Extensions.Hosting.AspireKafkaProducerExtensions.AddKafkaProducer<TKey,TValue>(IHostApplicationBuilder, String, Action<KafkaProducerSettings>, Action<IServiceProvider,ProducerBuilder<TKey,TValue>>)>
+- <xref:Microsoft.Extensions.Hosting.AspireKafkaConsumerExtensions.AddKafkaConsumer<TKey,TValue>(IHostApplicationBuilder, String, Action<KafkaConsumerSettings>, Action<IServiceProvider,ConsumerBuilder<TKey,TValue>>)>
+
+Consider the following producer registration example:
 
 ```csharp
 builder.AddKafkaProducer<string, MyMessage>(


### PR DESCRIPTION
## Summary

Fix doc.

1. Current Kafka integration does not support distributed traces yet (PR is here https://github.com/dotnet/aspire/pull/5765)
2. https://github.com/dotnet/aspire/pull/4327 added ability to pull IServiceProvider to configureBuilder of AddKafkaConsumer and AddKafkaProducer




<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/messaging/kafka-integration.md](https://github.com/dotnet/docs-aspire/blob/57f6bfcec971091b2b74441ec319573c11fb4f1e/docs/messaging/kafka-integration.md) | [.NET Aspire Apache Kafka integration](https://review.learn.microsoft.com/en-us/dotnet/aspire/messaging/kafka-integration?branch=pr-en-us-1821) |


<!-- PREVIEW-TABLE-END -->