### PR TITLE
Restrict auto-merge

### DIFF
--- a/.github/policies/auto-merge.yml
+++ b/.github/policies/auto-merge.yml
@@ -8,36 +8,41 @@ where:
 configuration:
   resourceManagementConfiguration:
     eventResponderTasks:
-      - description: Approve and auto-squash-merge PRs to main labeled with 'auto-merge'
-        triggerOnOwnActions: true
-        if:
-          - payloadType: Pull_Request
-          - labelAdded:
-              label: ":octocat: auto-merge"
-          - targetsBranch:
-              branch: main
-        then:
-          - approvePullRequest:
-              comment: "Approved; this PR will merge when all status checks pass."
-          - enableAutoMerge:
-              mergeMethod: Squash
+    - description: Approve and auto-squash-merge bot PRs to main labeled 'auto-merge'
+      triggerOnOwnActions: true
+      if:
+        - payloadType: Pull_Request
+        - labelAdded:
+            label: ':octocat: auto-merge'
+        - targetsBranch:
+            branch: main
+        - or:
+            - isActivitySender:
+                user: dotnet-policy-service[bot]
+      then:
+        - enableAutoMerge:
+            mergeMethod: Squash
+        - approvePullRequest:
+            comment: "Approved; this PR will merge when all status checks pass."
 
-      - description: Auto-merge PRs to live labeled with 'auto-merge'
-        triggerOnOwnActions: true
-        if:
-          - payloadType: Pull_Request
-          - labelAdded:
-              label: ":octocat: auto-merge"
-          - targetsBranch:
-              branch: live
-        then:
-          - enableAutoMerge:
-              mergeMethod: Merge
+    - description: Auto-merge policy service bot PRs to live labeled 'auto-merge'
+      triggerOnOwnActions: true
+      if:
+        - payloadType: Pull_Request
+        - labelAdded:
+            label: ':octocat: auto-merge'
+        - targetsBranch:
+            branch: live
+        - isActivitySender:
+            user: dotnet-policy-service[bot]
+      then:
+        - enableAutoMerge:
+            mergeMethod: Merge
 
-      - description: Don't auto-merge PRs with 'auto-merge' label removed
-        if:
-          - payloadType: Pull_Request
-          - labelRemoved:
-              label: ":octocat: auto-merge"
-        then:
-          - disableAutoMerge
+    - description: Don't auto-merge PRs with 'auto-merge' label removed
+      if:
+        - payloadType: Pull_Request
+        - labelRemoved:
+            label: ':octocat: auto-merge'
+      then:
+        - disableAutoMerge


### PR DESCRIPTION
Restrict auto-merge to PRs with auto-merge labels that were added by the dotnet policy service bot.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [.github/policies/auto-merge.yml](https://github.com/dotnet/docs-aspire/blob/b275faa4d6d9876f61abac7b3de4cd419748f588/.github/policies/auto-merge.yml) | [.github/policies/auto-merge](https://review.learn.microsoft.com/en-us/dotnet/aspire/.github/policies/auto-merge?branch=pr-en-us-1860) |

<!-- PREVIEW-TABLE-END -->