### PR TITLE
Allow Anonymous By Default

### DIFF
--- a/docs/fundamentals/dashboard/standalone.md
+++ b/docs/fundamentals/dashboard/standalone.md
@@ -24,6 +24,7 @@ The dashboard is started using the Docker command line.
 docker run --rm -it -d \
     -p 18888:18888 \
     -p 4317:18889 \
+    -e DOTNET_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS=true \
     --name aspire-dashboard \
     mcr.microsoft.com/dotnet/aspire-dashboard:8.2
 ```
@@ -34,6 +35,7 @@ docker run --rm -it -d \
 docker run --rm -it -d `
     -p 18888:18888 `
     -p 4317:18889 `
+    -e DOTNET_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS=true `
     --name aspire-dashboard `
     mcr.microsoft.com/dotnet/aspire-dashboard:8.2
 ```


### PR DESCRIPTION
## Summary

Since dotnet aspire dashboard is mainly for development, maybe it would be better to allow anonymous by default in a convenient way?


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/dashboard/standalone.md](https://github.com/dotnet/docs-aspire/blob/e72bc91dcea58fcfb1c89705afb5b12980f07119/docs/fundamentals/dashboard/standalone.md) | [Standalone .NET Aspire dashboard](https://review.learn.microsoft.com/en-us/dotnet/aspire/fundamentals/dashboard/standalone?branch=pr-en-us-1871) |

<!-- PREVIEW-TABLE-END -->