### PR TITLE
Create community toolkit docs request issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/05-community-toolkit-docs-request.yml
+++ b/.github/ISSUE_TEMPLATE/05-community-toolkit-docs-request.yml
@@ -1,0 +1,71 @@
+name: "Community Toolkit article request"
+description: Request a new article on a topic or concept related to the [Aspire Community Toolkit](https://github.com/CommunityToolkit/Aspire) that you can't find in our current docs.
+title: "[Community Toolkit New article]: "
+labels: ["doc-idea", "community-toolkit"]
+assignees: ["Alirexaa", "aaronpowell"]
+body:
+  - type: markdown
+    attributes:
+      value: "## Request a new article"
+  - type: markdown
+    attributes:
+      value: "Describe the proposed new article for us."
+  - type: input
+    id: topic
+    attributes:
+      label: Proposed topic or title
+      description: Write a short title or description of the topic
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: >
+        "Propose a location for the article. Use the `/` character to
+        define 'sub-folders' in the table of contents. Start with a top-level
+        guide, and follow through to the parent folder for the new article."
+  - type: input
+    id: toc-item
+    attributes:
+      label: Location in table of contents.
+      description: Give some indication for the location in the table of contents.
+    validations:
+      required: false
+  - type: markdown
+    attributes:
+      value: >
+        "Explain why the article is needed. What will readers learn? Why is
+        it important? What are the consequences if readers don't learn the topic?"
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Reason for the article
+      description: Tell us why this article is needed.
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: >
+        "Write an opening paragraph or abstract to explain what readers
+        will learn from reading this article."
+  - type: textarea
+    id: abstract
+    attributes:
+      label: Article abstract
+      description: Write a *brief* abstract for the article.
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: >
+        "Tell us about searches you did looking for this information. This helps us
+        in two important ways. First, if the information exists, we can improve
+        the findability of the article for those search ideas. If the article
+        doesn't exist, this will help us make sure readers find it once it's written."
+  - type: textarea
+    id: searches
+    attributes:
+      label: Relevant searches
+      description: >
+        What search terms did you use to look for this information?
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/05-community-toolkit-docs-request.yml
+++ b/.github/ISSUE_TEMPLATE/05-community-toolkit-docs-request.yml
@@ -23,13 +23,6 @@ body:
         "Propose a location for the article. Use the `/` character to
         define 'sub-folders' in the table of contents. Start with a top-level
         guide, and follow through to the parent folder for the new article."
-  - type: input
-    id: toc-item
-    attributes:
-      label: Location in table of contents.
-      description: Give some indication for the location in the table of contents.
-    validations:
-      required: false
   - type: markdown
     attributes:
       value: >


### PR DESCRIPTION
## Summary

This pull request introduces a new issue template for requesting articles related to the Aspire Community Toolkit. The template is designed to streamline the process for community members to propose new documentation topics.

This issue template is not necessary but it's very helpful to track Community Toolkit docs issues.

### New Issue Template for Documentation Requests:

* **Template Name and Description**: Added a new issue template named "Community Toolkit article request" with a description to guide users on requesting new articles. (`.github/ISSUE_TEMPLATE/05-community-toolkit-docs-request.yml`)
* **Template Structure**: 
  * **Title and Labels**: Predefined title prefix and labels for the issue. (`.github/ISSUE_TEMPLATE/05-community-toolkit-docs-request.yml`)
  * **Form Fields**: Various fields to capture the proposed topic, location in the table of contents, motivation for the article, abstract, and relevant searches. (`.github/ISSUE_TEMPLATE/05-community-toolkit-docs-request.yml`)
* **Assignees**: Assigned to specific team members to handle the requests. (`.github/ISSUE_TEMPLATE/05-community-toolkit-docs-request.yml`)

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [.github/ISSUE_TEMPLATE/05-community-toolkit-docs-request.yml](https://github.com/dotnet/docs-aspire/blob/4ca900c34ca8786b9f91d62537fe08738547a5f4/.github/ISSUE_TEMPLATE/05-community-toolkit-docs-request.yml) | ["[Community Toolkit New article]: "](https://review.learn.microsoft.com/en-us/dotnet/aspire/.github/ISSUE_TEMPLATE/05-community-toolkit-docs-request?branch=pr-en-us-1995) |


<!-- PREVIEW-TABLE-END -->