### PR TITLE
Remove extra markdown section from community-toolkit-docs-request issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/05-community-toolkit-docs-request.yml
+++ b/.github/ISSUE_TEMPLATE/05-community-toolkit-docs-request.yml
@@ -20,12 +20,6 @@ body:
   - type: markdown
     attributes:
       value: >
-        "Propose a location for the article. Use the `/` character to
-        define 'sub-folders' in the table of contents. Start with a top-level
-        guide, and follow through to the parent folder for the new article."
-  - type: markdown
-    attributes:
-      value: >
         "Explain why the article is needed. What will readers learn? Why is
         it important? What are the consequences if readers don't learn the topic?"
   - type: textarea


### PR DESCRIPTION
## Summary

Remove the markdown section because there is no input associated with this description.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [.github/ISSUE_TEMPLATE/05-community-toolkit-docs-request.yml](https://github.com/dotnet/docs-aspire/blob/e90b607ea9f8a7baa7d24ddd9b260954ccb493b2/.github/ISSUE_TEMPLATE/05-community-toolkit-docs-request.yml) | ["[Community Toolkit New article]: "](https://review.learn.microsoft.com/en-us/dotnet/aspire/.github/ISSUE_TEMPLATE/05-community-toolkit-docs-request?branch=pr-en-us-2039) |

<!-- PREVIEW-TABLE-END -->