### PR TITLE
Add xref to a few places, now that they're indexed

### DIFF
--- a/docs/app-host/eventing.md
+++ b/docs/app-host/eventing.md
@@ -1,7 +1,7 @@
 ---
 title: Eventing in .NET Aspire
 description: Learn how to use the .NET eventing features with .NET Aspire.
-ms.date: 10/30/2024
+ms.date: 11/13/2024
 ---
 
 # Eventing in .NET Aspire
@@ -40,9 +40,9 @@ The log output confirms that event handlers are executed in the order of the app
 
 In addition to the app host events, you can also subscribe to resource events. Resource events are raised specific to an individual resource. Resource events are defined as implementations of the <xref:Aspire.Hosting.Eventing.IDistributedApplicationResourceEvent> interface. The following resource events are available in the listed order:
 
-1. `ConnectionStringAvailableEvent`: Raised when a connection string becomes available for a resource.
-1. `BeforeResourceStartedEvent`: Raised before the orchestrator starts a new resource.
-1. `ResourceReadyEvent`: Raised when a resource initially transitions to a ready state.
+1. <xref:Aspire.Hosting.ApplicationModel.ConnectionStringAvailableEvent>: Raised when a connection string becomes available for a resource.
+1. <xref:Aspire.Hosting.ApplicationModel.BeforeResourceStartedEvent>: Raised before the orchestrator starts a new resource.
+1. <xref:Aspire.Hosting.ApplicationModel.ResourceReadyEvent>: Raised when a resource initially transitions to a ready state.
 
 ### Subscribe to resource events
 
@@ -66,22 +66,15 @@ When subscribing to any of the built-in events, you don't need to publish the ev
 Then, you can subscribe and publish the event by calling the either of the following APIs:
 
 - <xref:Aspire.Hosting.Eventing.IDistributedApplicationEventing.PublishAsync``1(``0,System.Threading.CancellationToken)>: Publishes an event to all subscribes of the specific event type.
-- `PublishAsync<T>(T, EventDispatchBehavior, CancellationToken)`: Publishes an event to all subscribes of the specific event type with a specified dispatch behavior.
+- <xref:Aspire.Hosting.Eventing.IDistributedApplicationEventing.PublishAsync``1(``0,Aspire.Hosting.Eventing.EventDispatchBehavior,System.Threading.CancellationToken)>: Publishes an event to all subscribes of the specific event type with a specified dispatch behavior.
 
 ### Provide an `EventDispatchBehavior`
 
 When events are dispatched, you can control how the events are dispatched to subscribers. The event dispatch behavior is specified with the `EventDispatchBehavior` enum. The following behaviors are available:
 
-<!--
-- <xref:Aspire.Hosting.Eventing.EventDispatchBehavior.BlockingSequential>: Fires events sequentially and blocks until they're all processed.
-- <xref:Aspire.Hosting.Eventing.EventDispatchBehavior.BlockingConcurrent>: Fires events concurrently and blocks until they are all processed.
-- <xref:Aspire.Hosting.Eventing.EventDispatchBehavior.NonBlockingSequential>: Fires events sequentially but doesn't block.
-- <xref:Aspire.Hosting.Eventing.EventDispatchBehavior.NonBlockingConcurrent>: Fires events concurrently but doesn't block.
--->
-
-- `EventDispatchBehavior.BlockingSequential`: Fires events sequentially and blocks until they're all processed.
-- `EventDispatchBehavior.BlockingConcurrent`: Fires events concurrently and blocks until they're all processed.
-- `EventDispatchBehavior.NonBlockingSequential`: Fires events sequentially but doesn't block.
-- `EventDispatchBehavior.NonBlockingConcurrent`: Fires events concurrently but doesn't block.
+- <xref:Aspire.Hosting.Eventing.EventDispatchBehavior.BlockingSequential?displayProperty=nameWithType>: Fires events sequentially and blocks until they're all processed.
+- <xref:Aspire.Hosting.Eventing.EventDispatchBehavior.BlockingConcurrent?displayProperty=nameWithType>: Fires events concurrently and blocks until they are all processed.
+- <xref:Aspire.Hosting.Eventing.EventDispatchBehavior.NonBlockingSequential?displayProperty=nameWithType>: Fires events sequentially but doesn't block.
+- <xref:Aspire.Hosting.Eventing.EventDispatchBehavior.NonBlockingConcurrent?displayProperty=nameWithType>: Fires events concurrently but doesn't block.
 
 The default behavior is `EventDispatchBehavior.BlockingSequential`. To override this behavior, when calling a publishing API such as <xref:Aspire.Hosting.Eventing.IDistributedApplicationEventing.PublishAsync*>, provide the desired behavior as an argument.

--- a/docs/fundamentals/app-host-overview.md
+++ b/docs/fundamentals/app-host-overview.md
@@ -89,8 +89,8 @@ The preceding code:
 - Adds a project resource named "apiservice" using the <xref:Aspire.Hosting.ProjectResourceBuilderExtensions.AddProject%2A> method.
 - Adds a project resource named "webfrontend" using the <xref:Aspire.Hosting.ProjectResourceBuilderExtensions.AddProject%2A> method.
   - Specifies that the project has external HTTP endpoints using the <xref:Aspire.Hosting.ResourceBuilderExtensions.WithExternalHttpEndpoints%2A> method.
-  - Adds a reference to the `cache` resource and waits for it to be ready using the <xref:Aspire.Hosting.ResourceBuilderExtensions.WithReference%2A> and `WaitFor` methods.
-  - Adds a reference to the `apiservice` resource and waits for it to be ready using the <xref:Aspire.Hosting.ResourceBuilderExtensions.WithReference%2A> and `WaitFor` methods.
+  - Adds a reference to the `cache` resource and waits for it to be ready using the <xref:Aspire.Hosting.ResourceBuilderExtensions.WithReference%2A> and <xref:Aspire.Hosting.ResourceBuilderExtensions.WaitFor*> methods.
+  - Adds a reference to the `apiservice` resource and waits for it to be ready using the <xref:Aspire.Hosting.ResourceBuilderExtensions.WithReference%2A> and <xref:Aspire.Hosting.ResourceBuilderExtensions.WaitFor*> methods.
 - Builds and runs the app model using the <xref:Aspire.Hosting.DistributedApplicationBuilder.Build%2A> and <xref:Aspire.Hosting.DistributedApplication.Run%2A> methods.
 
 The example code uses the [.NET Aspire Redis hosting integration](../caching/stackexchange-redis-integration.md#hosting-integration).
@@ -140,7 +140,7 @@ The "webfrontend" project resource uses <xref:Aspire.Hosting.ResourceBuilderExte
 
 ### Waiting for resources
 
-In some cases, you might want to wait for a resource to be ready before starting another resource. For example, you might want to wait for a database to be ready before starting an API that depends on it. To express this dependency, use the `WaitFor` method:
+In some cases, you might want to wait for a resource to be ready before starting another resource. For example, you might want to wait for a database to be ready before starting an API that depends on it. To express this dependency, use the <xref:Aspire.Hosting.ResourceBuilderExtensions.WaitFor*> method:
 
 ```csharp
 var builder = DistributedApplication.CreateBuilder(args);
@@ -155,7 +155,7 @@ builder.AddProject<Projects.AspireApp_ApiService>("apiservice")
 
 In the preceding code, the "apiservice" project resource waits for the "postgresdb" database resource to enter the <xref:Aspire.Hosting.ApplicationModel.KnownResourceStates.Running?displayProperty=nameWithType>. The example code shows the [.NET Aspire PostgreSQL integration](../database/postgresql-integration.md), but the same pattern can be applied to other resources.
 
-Other cases might warrant waiting for a resource to run to completion, either <xref:Aspire.Hosting.ApplicationModel.KnownResourceStates.Exited?displayProperty=nameWithType> or <xref:Aspire.Hosting.ApplicationModel.KnownResourceStates.Finished?displayProperty=nameWithType> before the dependent resource starts. To wait for a resource to run to completion, use the `WaitForCompletion` method:
+Other cases might warrant waiting for a resource to run to completion, either <xref:Aspire.Hosting.ApplicationModel.KnownResourceStates.Exited?displayProperty=nameWithType> or <xref:Aspire.Hosting.ApplicationModel.KnownResourceStates.Finished?displayProperty=nameWithType> before the dependent resource starts. To wait for a resource to run to completion, use the <xref:Aspire.Hosting.ResourceBuilderExtensions.WaitForCompletion*> method:
 
 ```csharp
 var builder = DistributedApplication.CreateBuilder(args);
@@ -222,12 +222,16 @@ When the app host is run, the <xref:Aspire.Hosting.ApplicationModel.ContainerRes
 
 #### [Docker](#tab/docker)
 
+First, the container is created using the `docker container create` command. Then, the container is started using the `docker container start` command.
+
 - [docker container create](https://docs.docker.com/reference/cli/docker/container/create/): Creates a new container from the specified image, without starting it.
 - [docker container start](https://docs.docker.com/reference/cli/docker/container/start/): Start one or more stopped containers.
 
 These commands are used instead of `docker run` to manage attached container networks, volumes, and ports. Calling these commands in this order allows any IP (network configuration) to already be present at initial startup.
 
 #### [Podman](#tab/podman)
+
+First, the container is created using the `podman container create` command. Then, the container is started using the `podman container start` command.
 
 - [podman container create](https://docs.podman.io/en/latest/markdown/podman-create.1.html): Creates a writable container layer over the specified image and prepares it for running.
 - [podman container start](https://docs.podman.io/en/latest/markdown/podman-start.1.html): Start one or more stopped containers.
@@ -291,7 +295,7 @@ The `port` parameter is the port that the container is listening on. For more in
 
 ### Service endpoint environment variable format
 
-In the preceding section, the `WithReference` method is used to express dependencies between resources. When service endpoints result in environment variables being injected into the dependent resource, the format might not be obvious. This section provides details on this format.
+In the preceding section, the <xref:Aspire.Hosting.ResourceBuilderExtensions.WithReference*> method is used to express dependencies between resources. When service endpoints result in environment variables being injected into the dependent resource, the format might not be obvious. This section provides details on this format.
 
 When one resource depends on another resource, the app host injects environment variables into the dependent resource. These environment variables configure the dependent resource to connect to the resource it depends on. The format of the environment variables is specific to .NET Aspire and expresses service endpoints in a way that is compatible with [Service Discovery](../service-discovery/overview.md).
 

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -11,7 +11,7 @@ metadata:
   description: Learn about .NET Aspire, a cloud-ready stack for building distributed applications. Browse API reference, tutorials, and more.
   ms.topic: hub-page
   ms.service: dotnet-aspire
-  ms.date: 10/23/2024
+  ms.date: 11/13/2024
 
 highlightedContent:
   items:
@@ -247,6 +247,9 @@ conceptualContent:
         - itemType: training
           text: Send messages with RabbitMQ in a .NET Aspire project
           url: /training/modules/send-messages-rabbitmq-dotnet-aspire-app/
+        - itemType: architecture
+          text: .NET Aspire Credential (Applied Skill)
+          url: /credentials/applied-skills/build-distributed-apps-with-dotnet-aspire/
 
 additionalContent:
   sections:

--- a/docs/serverless/functions.md
+++ b/docs/serverless/functions.md
@@ -1,7 +1,7 @@
 ---
 title: .NET Aspire Azure Functions integration (Preview)
 description: Learn how to integrate Azure Functions with .NET Aspire.
-ms.date: 10/31/2024
+ms.date: 11/13/2024
 zone_pivot_groups: dev-environment
 ---
 
@@ -58,7 +58,7 @@ Currently, deployment is supported only to containers on Azure Container Apps (A
 
 #### Configure external HTTP endpoints
 
-To make HTTP triggers publicly accessible, call the `WithExternalHttpEndpoints` API on the `AzureFunctionsProjectResource`. For more information, see [Add Azure Functions resource](#add-azure-functions-resource).
+To make HTTP triggers publicly accessible, call the <xref:Aspire.Hosting.ResourceBuilderExtensions.WithExternalHttpEndpoints*> API on the <xref:Aspire.Hosting.Azure.AzureFunctionsProjectResource>. For more information, see [Add Azure Functions resource](#add-azure-functions-resource).
 
 ## Azure Function project constraints
 
@@ -86,7 +86,7 @@ In Visual Studio, try checking for an update on the Azure Functions tooling. Ope
 
 ## Hosting integration
 
-The Azure Functions hosting integration models an Azure Functions resource as the `AzureFunctionsProjectResource` (subtype of <xref:Aspire.Hosting.ApplicationModel.ProjectResource>) type. To access this type and APIs that allow you to add it to your [📦 Aspire.Hosting.Azure.Functions) NuGet package in the [app host](xref:dotnet/aspire/app-host](https://www.nuget.org/packages/Aspire.Hosting.Azure.Functions) NuGet package in the [app host](xref:dotnet/aspire/app-host) project.
+The Azure Functions hosting integration models an Azure Functions resource as the <xref:Aspire.Hosting.Azure.AzureFunctionsProjectResource> (subtype of <xref:Aspire.Hosting.ApplicationModel.ProjectResource>) type. To access this type and APIs that allow you to add it to your [app host](xref:dotnet/aspire/app-host) project install the [📦 Aspire.Hosting.Azure.Functions](https://www.nuget.org/packages/Aspire.Hosting.Azure.Functions) NuGet package.
 
 ### [.NET CLI](#tab/dotnet-cli)
 
@@ -107,7 +107,7 @@ For more information, see [dotnet add package](/dotnet/core/tools/dotnet-add-pac
 
 ### Add Azure Functions resource
 
-In your app host project, call `AddAzureFunctionsProject` on the `builder` instance to add an Azure Functions resource:
+In your app host project, call <xref:Aspire.Hosting.AzureFunctionsProjectResourceExtensions.AddAzureFunctionsProject*> on the `builder` instance to add an Azure Functions resource:
 
 ```csharp
 var builder = DistributedApplication.CreateBuilder(args);
@@ -126,7 +126,7 @@ When .NET Aspire adds an Azure Functions project resource the app host, as shown
 
 ### Add Azure Functions resource with host storage
 
-If you want to modify the default host storage account that the Azure Functions host uses, call the `WithHostStorage` method on the Azure Functions project resource:
+If you want to modify the default host storage account that the Azure Functions host uses, call the <xref:Aspire.Hosting.AzureFunctionsProjectResourceExtensions.WithHostStorage*> method on the Azure Functions project resource:
 
 ```csharp
 var builder = DistributedApplication.CreateBuilder(args);
@@ -173,4 +173,4 @@ The preceding code adds an Azure Storage resource to the app host and references
 - [.NET Aspire integrations](../fundamentals/integrations-overview.md)
 - [.NET Aspire GitHub repo](https://github.com/dotnet/aspire)
 - [Azure Functions documentation](/azure/azure-functions/functions-overview)
-<!-- - [.NET Aspire and Functions image gallery sample](/samples/dotnet/aspire-samples/aspire-azure-functions-with-blob-triggers) -->
+- [.NET Aspire and Functions image gallery sample](/samples/dotnet/aspire-samples/aspire-azure-functions-with-blob-triggers)

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -366,6 +366,8 @@ items:
     items:
       - name: .NET Aspire
         href: https://github.com/dotnet/aspire
+      - name: .NET Aspire Credential
+        href: /credentials/applied-skills/build-distributed-apps-with-dotnet-aspire/
       - name: .NET Aspire samples
         href: https://github.com/dotnet/aspire-samples
       - name: .NET Aspire samples browser

--- a/docs/whats-new/dotnet-aspire-9.md
+++ b/docs/whats-new/dotnet-aspire-9.md
@@ -1,7 +1,7 @@
 ---
 title: What's new in .NET Aspire 9.0
 description: Learn what's new in the official general availability version of .NET Aspire 9.0.
-ms.date: 11/11/2024
+ms.date: 11/13/2024
 ---
 
 # What's new in .NET Aspire 9.0
@@ -122,12 +122,10 @@ builder.Build().Run();
 
 When the app host starts, it waits for the `rabbit` resource to be ready before starting the `api` resource.
 
-<!-- TODO: xref -->
-
 There are two methods exposed to wait for a resource:
 
-- `WaitFor`: Wait for a resource to be ready before starting another resource.
-- `WaitForCompletion`: Wait for a resource to complete before starting another resource.
+- <xref:Aspire.Hosting.ResourceBuilderExtensions.WaitFor*>: Wait for a resource to be ready before starting another resource.
+- <xref:Aspire.Hosting.ResourceBuilderExtensions.WaitForCompletion*>: Wait for a resource to complete before starting another resource.
 
 For more information, see [.NET Aspire app host: Waiting for resources](../fundamentals/app-host-overview.md#waiting-for-resources).
 
@@ -189,9 +187,7 @@ builder.AddProject<Projects.MyApp>("myapp")
 
 The preceding example adds a health check to the `cache` resource, which reports it as unhealthy for the first 20 seconds after the app host starts. So, the `myapp` resource waits for 20 seconds before starting, ensuring the `cache` resource is healthy.
 
-<!-- TODO: xref -->
-
-The <xref:Microsoft.Extensions.DependencyInjection.HealthChecksBuilderAddCheckExtensions.AddCheck*> and `WithHealthCheck` methods provide a simple mechanism to create health checks and associate them with specific resources.
+The <xref:Microsoft.Extensions.DependencyInjection.HealthChecksBuilderAddCheckExtensions.AddCheck*> and <xref:Aspire.Hosting.ResourceBuilderExtensions.WithHealthCheck*> methods provide a simple mechanism to create health checks and associate them with specific resources.
 
 ### Persistent containers
 
@@ -202,9 +198,7 @@ This is useful when you want to keep the container running even after the app ho
 > [!IMPORTANT]
 > To delete these containers, you must manually stop them using the container runtime.
 
-<!-- TODO: xref -->
-
-To define an `IResourceBuilder<ContainerResource>` with a persistent lifetime, call the `WithLifetime` method and pass in `ContainerLifetime.Persistent`:
+To define an `IResourceBuilder<ContainerResource>` with a persistent lifetime, call the <xref:Aspire.Hosting.ContainerResourceBuilderExtensions.WithLifetime*> method and pass in <xref:Aspire.Hosting.ApplicationModel.ContainerLifetime.Persistent?displayProperty=nameWithType>:
 
 ```csharp
 var builder = DistributedApplication.CreateBuilder(args);
@@ -248,21 +242,19 @@ The app host now adds all containers to a common network named `default-aspire-n
 
 The eventing model allows developers to hook into the lifecycle of the application and resources. This is useful for running custom code at specific points in the application lifecycle. There are various ways to subscribe to events, including global events and per-resource events.
 
-<!-- TODO: xref -->
-
 **Global events:**
 
-- `BeforeStartEvent`: An event that is triggered before the application starts. This is the last place that changes to the app model are observed. This runs in both "Run" and "Publish" modes. This is a blocking event, meaning that the application doesn't start until all handlers have completed.
-- `AfterResourcesCreatedEvent`: An event that is triggered after the resources are created. This runs in Run mode only.
-- `AfterEndpointsAllocatedEvent`: An event that is triggered after the endpoints are allocated for all resources. This runs in Run mode only.
+- <xref:Aspire.Hosting.ApplicationModel.BeforeStartEvent>: An event that is triggered before the application starts. This is the last place that changes to the app model are observed. This runs in both "Run" and "Publish" modes. This is a blocking event, meaning that the application doesn't start until all handlers have completed.
+- <xref:Aspire.Hosting.ApplicationModel.AfterResourcesCreatedEvent>: An event that is triggered after the resources are created. This runs in Run mode only.
+- <xref:Aspire.Hosting.ApplicationModel.AfterEndpointsAllocatedEvent>: An event that is triggered after the endpoints are allocated for all resources. This runs in Run mode only.
 
 The global events are analogous to the app host life cycle events. For more information, see [App host life cycles](../fundamentals/app-host-overview.md#app-host-life-cycles).
 
 **Per-resource events:**
 
-- `BeforeResourceStartedEvent`: An event that is triggered before a single resource starts. This runs in Run mode only. This is a blocking event, meaning that the resource doesn't start until all handlers complete.
-- `ConnectionStringAvailableEvent`: An event that is triggered when a connection string is available for a resource. This runs in Run mode only.
-- `ResourceReadyEvent`: An event that is triggered when a resource is ready to be used. This runs in Run mode only.
+- <xref:Aspire.Hosting.ApplicationModel.BeforeResourceStartedEvent>: An event that is triggered before a single resource starts. This runs in Run mode only. This is a blocking event, meaning that the resource doesn't start until all handlers complete.
+- <xref:Aspire.Hosting.ApplicationModel.ConnectionStringAvailableEvent>: An event that is triggered when a connection string is available for a resource. This runs in Run mode only.
+- <xref:Aspire.Hosting.ApplicationModel.ResourceReadyEvent>: An event that is triggered when a resource is ready to be used. This runs in Run mode only.
 
 For more information, see [Eventing in .NET Aspire](../app-host/eventing.md).
 
@@ -283,9 +275,7 @@ builder.AddRedis("redis")
                             // Redis instance.
 ```
 
-<!-- TODO: xref -->
-
-The `WithRedisInsight` extension method can be applied to multiple Redis resources and they'll each be visible on the Redis Insight dashboard.
+The <xref:Aspire.Hosting.RedisBuilderExtensions.WithRedisInsight*> extension method can be applied to multiple Redis resources and they'll each be visible on the Redis Insight dashboard.
 
 :::image type="content" source="media/redis-insight.png" lightbox="media/redis-insight.png" alt-text="Redis Insight dashboard showing multiple Redis instances":::
 
@@ -297,9 +287,7 @@ Starting with .NET Aspire 9, an additional OpenAI integration is available which
 
 - [ðŸ“¦ Aspire.OpenAI (Preview)](https://www.nuget.org/packages/Aspire.OpenAI/9.0.0)
 
-<!-- TODO: xref -->
-
-Moreover, the already available [.NET Aspire Azure OpenAI integration](../azureai/azureai-openai-integration.md) was improved to provide a flexible way to configure an `OpenAIClient` for either an Azure AI OpenAI service or a dedicated OpenAI REST API one with the new `AddOpenAIClientFromConfiguration` builder method. The following example detects if the connection string is for an Azure AI OpenAI service and registers the most appropriate `OpenAIClient` instance automatically.
+Moreover, the already available [.NET Aspire Azure OpenAI integration](../azureai/azureai-openai-integration.md) was improved to provide a flexible way to configure an `OpenAIClient` for either an Azure AI OpenAI service or a dedicated OpenAI REST API one with the new <xref:Microsoft.Extensions.Hosting.AspireConfigurableOpenAIExtensions.AddOpenAIClientFromConfiguration(Microsoft.Extensions.Hosting.IHostApplicationBuilder,System.String)> builder method. The following example detects if the connection string is for an Azure AI OpenAI service and registers the most appropriate `OpenAIClient` instance automatically.
 
 ```csharp
 builder.AddOpenAIClientFromConfiguration("openai");
@@ -311,9 +299,7 @@ Read [Azure-agnostic client resolution](https://github.com/dotnet/aspire/blob/re
 
 ### MongoDB
 
-<!-- TODO: xref -->
-
-Added support for specifying the MongoDB username and password when using the `AddMongoDB` extension method. If not specified, a random username and password is generated but can be manually specified using parameter resources.
+Added support for specifying the MongoDB username and password when using the <xref:Aspire.Hosting.MongoDBBuilderExtensions.AddMongoDB(Aspire.Hosting.IDistributedApplicationBuilder,System.String,System.Nullable{System.Int32},Aspire.Hosting.ApplicationModel.IResourceBuilder{Aspire.Hosting.ApplicationModel.ParameterResource},Aspire.Hosting.ApplicationModel.IResourceBuilder{Aspire.Hosting.ApplicationModel.ParameterResource})> extension method. If not specified, a random username and password is generated but can be manually specified using parameter resources.
 
 ```csharp
 var builder = DistributedApplication.CreateBuilder(args);
@@ -421,9 +407,7 @@ In the app host project, observe that there's a `PackageReference` to the new [ð
 </ItemGroup>
 ```
 
-<!-- TODO: xref -->
-
-This package provides an `AddAzureFunctionsProject` API that can be invoked in the app host to configure Azure Functions projects within an .NET Aspire host:
+This package provides an <xref:Aspire.Hosting.AzureFunctionsProjectResourceExtensions.AddAzureFunctionsProject``1(Aspire.Hosting.IDistributedApplicationBuilder,System.String)> API that can be invoked in the app host to configure Azure Functions projects within an .NET Aspire host:
 
 ```csharp
 var builder = DistributedApplication.CreateBuilder(args);
@@ -669,16 +653,14 @@ For more information, see the official [.NET Aspire Azure Functions integration 
 
 #### Customization of Azure Container Apps
 
-<!-- TODO: xref -->
-
-One of the most requested features is the ability to customize the Azure Container Apps that the app host creates without touching Bicep. This is possible by using the `PublishAsAzureContainerApp` method in the `Aspire.Hosting.Azure.AppContainers` namespace. This method customizes the Azure Container App definition that the app host creates.
+One of the most requested features is the ability to customize the Azure Container Apps that the app host creates without touching Bicep. This is possible by using the <xref:Aspire.Hosting.AzureContainerAppProjectExtensions.PublishAsAzureContainerApp``1(Aspire.Hosting.ApplicationModel.IResourceBuilder{``0},System.Action{Aspire.Hosting.Azure.AzureResourceInfrastructure,Azure.Provisioning.AppContainers.ContainerApp})> and <xref:Aspire.Hosting.AzureContainerAppContainerExtensions.PublishAsAzureContainerApp``1(Aspire.Hosting.ApplicationModel.IResourceBuilder{``0},System.Action{Aspire.Hosting.Azure.AzureResourceInfrastructure,Azure.Provisioning.AppContainers.ContainerApp})> APIs in the `Aspire.Hosting.Azure.AppContainers` namespace. These methods customizes the Azure Container App definition that the app host creates.
 
 Add the package reference to your project file:
 
 ```xml
 <ItemGroup>
   <PackageReference Include="Aspire.Hosting.Azure.AppContainers"
-                    Version="9.0.0-rc.1.24511.1" />
+                    Version="9.0.0" />
 </ItemGroup>
 ```
 


### PR DESCRIPTION
## Summary

Add xref to a few places, now that they're indexed

Fixes #2083

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/app-host/eventing.md](https://github.com/dotnet/docs-aspire/blob/2b490fea4168db9a1d7eee4af32ec5fe644fdee1/docs/app-host/eventing.md) | [Eventing in .NET Aspire](https://review.learn.microsoft.com/en-us/dotnet/aspire/app-host/eventing?branch=pr-en-us-2084) |
| [docs/fundamentals/app-host-overview.md](https://github.com/dotnet/docs-aspire/blob/2b490fea4168db9a1d7eee4af32ec5fe644fdee1/docs/fundamentals/app-host-overview.md) | [.NET Aspire orchestration overview](https://review.learn.microsoft.com/en-us/dotnet/aspire/fundamentals/app-host-overview?branch=pr-en-us-2084) |
| [docs/index.yml](https://github.com/dotnet/docs-aspire/blob/2b490fea4168db9a1d7eee4af32ec5fe644fdee1/docs/index.yml) | [.NET Aspire documentation](https://review.learn.microsoft.com/en-us/dotnet/aspire/index?branch=pr-en-us-2084) |
| [docs/serverless/functions.md](https://github.com/dotnet/docs-aspire/blob/2b490fea4168db9a1d7eee4af32ec5fe644fdee1/docs/serverless/functions.md) | [.NET Aspire Azure Functions integration (Preview)](https://review.learn.microsoft.com/en-us/dotnet/aspire/serverless/functions?branch=pr-en-us-2084) |
| [docs/toc.yml](https://github.com/dotnet/docs-aspire/blob/2b490fea4168db9a1d7eee4af32ec5fe644fdee1/docs/toc.yml) | [docs/toc](https://review.learn.microsoft.com/en-us/dotnet/aspire/toc?branch=pr-en-us-2084) |
| [docs/whats-new/dotnet-aspire-9.md](https://github.com/dotnet/docs-aspire/blob/2b490fea4168db9a1d7eee4af32ec5fe644fdee1/docs/whats-new/dotnet-aspire-9.md) | [What's new in .NET Aspire 9.0](https://review.learn.microsoft.com/en-us/dotnet/aspire/whats-new/dotnet-aspire-9?branch=pr-en-us-2084) |

<!-- PREVIEW-TABLE-END -->