### PR TITLE
Correct Aspire V8 naming change code

### DIFF
--- a/docs/compatibility/9.0/azure-resource-name-scheme.md
+++ b/docs/compatibility/9.0/azure-resource-name-scheme.md
@@ -62,7 +62,7 @@ var builder = DistributedApplication.CreateBuilder(args);
 
 builder.Services.Configure<AzureProvisioningOptions>(options =>
 {
-    options.ProvisioningContext.PropertyResolvers.Insert(0, new AzureResourceNamePropertyResolverAspireV8());
+    options.ProvisioningBuildOptions.InfrastructureResolvers.Insert(0, new AspireV8ResourceNamePropertyResolver());
 });
 ```
 

--- a/docs/whats-new/dotnet-aspire-9.md
+++ b/docs/whats-new/dotnet-aspire-9.md
@@ -325,10 +325,9 @@ As part of the update to the <xref:Azure.Provisioning> libraries, the default na
 ```csharp
 var builder = DistributedApplication.CreateBuilder(args);
 
-builder.Services.Configure<AzureResourceOptions>(options =>
+builder.Services.Configure<AzureProvisioningOptions>(options =>
 {
-    options.ProvisioningContext.PropertyResolvers.Insert(
-        0, new AspireV8ResourceNamePropertyResolver());
+    options.ProvisioningBuildOptions.InfrastructureResolvers.Insert(0, new AspireV8ResourceNamePropertyResolver());
 });
 ```
 


### PR DESCRIPTION
## Summary

The code snippets for maintaining compatibility with Aspire .NET 8 naming conventions is incorrect and does not compile. I've replaced it with the correct code, referenced from the unit tests:

https://github.com/dotnet/aspire/blob/9abbb30cabe217bd0d03ecd9793e7a7427a71675/tests/Aspire.Hosting.Azure.Tests/AzureResourceOptionsTests.cs#L29-L32

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/compatibility/9.0/azure-resource-name-scheme.md](https://github.com/dotnet/docs-aspire/blob/8d412acabe20a951ba207a746e9d6a8399ae4661/docs/compatibility/9.0/azure-resource-name-scheme.md) | [Better Azure resource name scheme](https://review.learn.microsoft.com/en-us/dotnet/aspire/compatibility/9.0/azure-resource-name-scheme?branch=pr-en-us-2087) |
| [docs/whats-new/dotnet-aspire-9.md](https://github.com/dotnet/docs-aspire/blob/8d412acabe20a951ba207a746e9d6a8399ae4661/docs/whats-new/dotnet-aspire-9.md) | [What's new in .NET Aspire 9.0](https://review.learn.microsoft.com/en-us/dotnet/aspire/whats-new/dotnet-aspire-9?branch=pr-en-us-2087) |

<!-- PREVIEW-TABLE-END -->