### PR TITLE
correct linking in RabbitMQ integration docs

### DIFF
--- a/docs/messaging/rabbitmq-integration.md
+++ b/docs/messaging/rabbitmq-integration.md
@@ -17,7 +17,7 @@ TODO: Diagram showing the thing we're integrating with and the components of the
 
 ## Hosting integration
 
-The RabbitMQ hosting integration models a RabbitMQ server as the <xref:Aspire.Hosting.ApplicationModel.RabbitMQServerResource> type. To access this type and APIs that allow you to add it to your [📦 Aspire.Hosting.RabbitMQ) NuGet package in the [app host](xref:dotnet/aspire/app-host](https://www.nuget.org/packages/Aspire.Hosting.RabbitMQ) NuGet package in the [app host](xref:dotnet/aspire/app-host) project.
+The RabbitMQ hosting integration models a RabbitMQ server as the <xref:Aspire.Hosting.ApplicationModel.RabbitMQServerResource> type. To access this type and its APIs add the [📦 Aspire.Hosting.RabbitMQ](https://www.nuget.org/packages/Aspire.Hosting.RabbitMQ) NuGet package in the [app host](xref:dotnet/aspire/app-host) project.
 
 ### [.NET CLI](#tab/dotnet-cli)
 


### PR DESCRIPTION


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/messaging/rabbitmq-integration.md](https://github.com/dotnet/docs-aspire/blob/aa5ab14a10138539f52489ff54488c8ed854d818/docs/messaging/rabbitmq-integration.md) | [.NET Aspire RabbitMQ integration](https://review.learn.microsoft.com/en-us/dotnet/aspire/messaging/rabbitmq-integration?branch=pr-en-us-2097) |

<!-- PREVIEW-TABLE-END -->