### PR TITLE
Fix how to specify kafka ui host port

### DIFF
--- a/docs/messaging/kafka-integration.md
+++ b/docs/messaging/kafka-integration.md
@@ -80,8 +80,7 @@ To change the Kafka UI host port, chain a call to the <xref:Aspire.Hosting.Kafka
 var builder = DistributedApplication.CreateBuilder(args);
 
 var kafka = builder.AddKafka("kafka")
-                   .WithKafkaUI()
-                   .WithHostPort(9100);
+                   .WithKafkaUI(kafkaUI => kafkaUI.WithHostPort(9100));
 
 builder.AddProject<Projects.ExampleProject>()
        .WithReference(kafka);


### PR DESCRIPTION
## Summary

The docs incorrectly show the `WithHostPort(...)` extension method on the `IResourceBuilder<KafkaServerResource>`.

This is true for v8.2.2 and v9.0.0

The below screenshot is from a Visual Studio project using v9.0.0.
![image](https://github.com/user-attachments/assets/f41394eb-be43-469f-81a1-ddf5deea2d27)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/messaging/kafka-integration.md](https://github.com/dotnet/docs-aspire/blob/9b57f4f5130f44c0c87a2586aec0b2c52de52e0a/docs/messaging/kafka-integration.md) | [.NET Aspire Apache Kafka integration](https://review.learn.microsoft.com/en-us/dotnet/aspire/messaging/kafka-integration?branch=pr-en-us-2132) |

<!-- PREVIEW-TABLE-END -->