### PR TITLE
Add note about WaitFor to Cosmos docs.

### DIFF
--- a/docs/database/azure-cosmos-db-integration.md
+++ b/docs/database/azure-cosmos-db-integration.md
@@ -87,9 +87,7 @@ var exampleProject = builder.AddProject<Projects.ExampleProject>()
 > cosmosdb.RunAsEmulator();
 > ```
 >
-> Starting the Cosmos DB emulator can take some time to start. If you have code in your service code that needs Cosmos to be
-> running you can use <xref:Aspire.Hosting.ResourceBuilderExtensions.WaitFor%2A> to delay the start of your .NET project code
-> until the emulator is running and *ready to serve requests*.
+> Starting the Cosmos DB emulator may take some time. Use <xref:Aspire.Hosting.ResourceBuilderExtensions.WaitFor%2A> to delay your .NET project's code execution until the emulator is running and ready to serve requests.
 >
 > ```csharp
 > var exampleProject = builder.AddProject<Projects.ExampleProject>()

--- a/docs/database/azure-cosmos-db-integration.md
+++ b/docs/database/azure-cosmos-db-integration.md
@@ -86,6 +86,16 @@ var exampleProject = builder.AddProject<Projects.ExampleProject>()
 > ```csharp
 > cosmosdb.RunAsEmulator();
 > ```
+>
+> Starting the Cosmos DB emulator can take some time to start. If you have code in your service code that needs Cosmos to be
+> running you can use <xref:Aspire.Hosting.ResourceBuilderExtensions.WaitFor%2A> to delay the start of your .NET project code
+> until the emulator is running and *ready to serve requests*.
+>
+> ```csharp
+> var exampleProject = builder.AddProject<Projects.ExampleProject>()
+>                             .WithReference(cosmosdb)
+>                             .WaitFor(cosmosdb);
+> ```
 
 ## Configuration
 


### PR DESCRIPTION
## Summary

Based on some internal feedback. Callout using WaitFor when the emulator is used.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/database/azure-cosmos-db-integration.md](https://github.com/dotnet/docs-aspire/blob/b66f8310fd39eaf095b766bb5646a092709080af/docs/database/azure-cosmos-db-integration.md) | [.NET Aspire Azure Cosmos DB integration](https://review.learn.microsoft.com/en-us/dotnet/aspire/database/azure-cosmos-db-integration?branch=pr-en-us-2152) |


<!-- PREVIEW-TABLE-END -->