### PR TITLE
Add tip about --framework option for creating Aspire projects with CLI

### DIFF
--- a/docs/fundamentals/aspire-sdk-templates.md
+++ b/docs/fundamentals/aspire-sdk-templates.md
@@ -160,7 +160,7 @@ Select the desired location, enter a name, and select **Create**.
 
 To create a .NET Aspire solution or project using the .NET CLI, use the [dotnet new](/dotnet/core/tools/dotnet-new) command and specify which template you would like to create. Consider the following examples:
 
-To create a basic [.NET Aspire app host](app-host-overview.md) project:
+To create a basic [.NET Aspire app host](app-host-overview.md) project targeting the latest .NET version:
 
 ```dotnetcli
 dotnet new aspire-apphost
@@ -171,6 +171,12 @@ To create a .NET Aspire starter app, which is a full solution with a sample UI a
 ```dotnetcli
 dotnet new aspire-starter
 ```
+
+> [!TIP]
+> .NET Aspire templates default to using the latest .NET version, even when using an earlier version of the .NET CLI. To manually specify the .NET version, use the `--framework <tfm>` option, e.g. to create a basic [.NET Aspire app host](app-host-overview.md) project targeting .NET 8:
+> ```dotnetcli
+> dotnet new aspire-apphost --framework net8.0
+> ```
 
 :::zone-end
 

--- a/docs/fundamentals/aspire-sdk-templates.md
+++ b/docs/fundamentals/aspire-sdk-templates.md
@@ -174,6 +174,7 @@ dotnet new aspire-starter
 
 > [!TIP]
 > .NET Aspire templates default to using the latest .NET version, even when using an earlier version of the .NET CLI. To manually specify the .NET version, use the `--framework <tfm>` option, e.g. to create a basic [.NET Aspire app host](app-host-overview.md) project targeting .NET 8:
+>
 > ```dotnetcli
 > dotnet new aspire-apphost --framework net8.0
 > ```


### PR DESCRIPTION
Adds a specific callout about using `--framework` to specify the .NET  version to use when creating Aspire projects using the .NET CLI.

Fixes microsoft/vscode-dotnettools#1643

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/aspire-sdk-templates.md](https://github.com/dotnet/docs-aspire/blob/3f67b48d938023d142821bcb83aaa02d2d152888/docs/fundamentals/aspire-sdk-templates.md) | [docs/fundamentals/aspire-sdk-templates](https://review.learn.microsoft.com/en-us/dotnet/aspire/fundamentals/aspire-sdk-templates?branch=pr-en-us-2174) |


<!-- PREVIEW-TABLE-END -->