### PR TITLE
Re-add issue automation

### DIFF
--- a/.github/workflows/create-monthly-issues.yml
+++ b/.github/workflows/create-monthly-issues.yml
@@ -39,11 +39,11 @@ jobs:
             const emoji = monthEmojis[month];
             const issueTitle = `${emoji} Repo chores—${monthName} ${year}`;
             const issueBody = `
-            - [ ] Check *An external link was removed to protect your privacy.* for \`dotnet/docs-aspire\`
-            - [ ] Fix build suggestions in \`dotnet/docs-aspire\`
-            - [ ] Check *An external link was removed to protect your privacy.* for \`dotnet/docs-aspire\`
+            - [ ] Check [UUF feedback](https://aka.ms/uuftriageapp) for `dotnet/docs-aspire`
+            - [ ] Fix build suggestions in `dotnet/docs-aspire`
+            - [ ] Check [broken links report](https://msit.powerbi.com/groups/me/reports/0a1183d7-baae-4d5d-9d71-7bb437e2b2b3/ReportSection5885348483cf9c5a907f?ctid=72f988bf-86f1-41af-91ab-2d7cd011db47&experience=power-bi) for `dotnet/docs-aspire`: #1863
             - [ ] Approve/merge CleanRepo PR
-            - [ ] Clean up hygiene items in *An external link was removed to protect your privacy.*
+            - [ ] Clean up hygiene items in [ADO board](https://dev.azure.com/msft-skilling/Content/_dashboards/dashboard/8132ec13-0654-4ffd-89a1-a1b9bcd77715)
 
             > [!NOTE]  
             > 🤖 This issue was created using [.github/workflows/create-monthly-issues.yml](https://github.com/dotnet/docs-aspire/blob/main/.github/workflows/create-monthly-issues.yml).


### PR DESCRIPTION
Not sure when this happened, but the links were automatically removed.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [.github/workflows/create-monthly-issues.yml](https://github.com/dotnet/docs-aspire/blob/8e5b1b5be859a0520cb9e2847ac3f266824841df/.github/workflows/create-monthly-issues.yml) | [.github/workflows/create-monthly-issues](https://review.learn.microsoft.com/en-us/dotnet/aspire/.github/workflows/create-monthly-issues?branch=pr-en-us-2294) |

<!-- PREVIEW-TABLE-END -->