### PR TITLE
Add Orleans Server & Client NuGet packages to guide

### DIFF
--- a/docs/frameworks/orleans.md
+++ b/docs/frameworks/orleans.md
@@ -93,6 +93,7 @@ In the folder for the Orleans server project, run these commands:
 ```dotnetcli
 dotnet add package Aspire.Azure.Data.Tables
 dotnet add package Aspire.Azure.Storage.Blobs
+dotnet add package Microsoft.Orleans.Server
 dotnet add package Microsoft.Orleans.Persistence.AzureStorage
 dotnet add package Microsoft.Orleans.Clustering.AzureStorage
 ```
@@ -132,6 +133,7 @@ In the Orleans client project, add the same NuGet packages:
 ```dotnetcli
 dotnet add package Aspire.Azure.Data.Tables
 dotnet add package Aspire.Azure.Storage.Blobs
+dotnet add package Microsoft.Orleans.Client
 dotnet add package Microsoft.Orleans.Persistence.AzureStorage
 dotnet add package Microsoft.Orleans.Clustering.AzureStorage
 ```


### PR DESCRIPTION
[This Reddit thread](https://www.reddit.com/r/dotnet/comments/1hzmc03/why_doesnt_this_aspire_project_work/) highlights that the current doc has a deficiency in that it misses these two packages

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/frameworks/orleans.md](https://github.com/dotnet/docs-aspire/blob/eb7f2cd9afda265d436b92aa6b9d90157dccbbee/docs/frameworks/orleans.md) | [.NET Aspire Orleans integration](https://review.learn.microsoft.com/en-us/dotnet/aspire/frameworks/orleans?branch=pr-en-us-2372) |

<!-- PREVIEW-TABLE-END -->