### PR TITLE
Add .NET Aspire SDK to prerequisites

### DIFF
--- a/docs/includes/aspire-prereqs.md
+++ b/docs/includes/aspire-prereqs.md
@@ -3,6 +3,7 @@
 To work with .NET Aspire, you need the following installed locally:
 
 - [.NET 8.0](https://dotnet.microsoft.com/download/dotnet/8.0) or [.NET 9.0](https://dotnet.microsoft.com/download/dotnet/9.0)
+- [.NET Aspire SDK](../fundamentals/dotnet-aspire-sdk.md).
 - An OCI compliant container runtime, such as:
   - [Docker Desktop](https://www.docker.com/products/docker-desktop) or [Podman](https://podman.io/). For more information, see [Container runtime](../fundamentals/setup-tooling.md#container-runtime).
 - An Integrated Developer Environment (IDE) or code editor, such as:


### PR DESCRIPTION
Add .NET Aspire SDK to prerequisites.
The result will match the prerequisites in [this page](https://learn.microsoft.com/en-us/dotnet/aspire/fundamentals/setup-tooling).