### PR TITLE
Remove platform extensions API ref link

### DIFF
--- a/docs/index.yml
+++ b/docs/index.yml
@@ -361,9 +361,6 @@ additionalContent:
         - title: ".NET Aspire API reference"
           summary: API reference documentation for .NET Aspire
           url: /dotnet/api?view=dotnet-aspire-9.0&preserve-view=true
-        - title: ".NET package-provided API reference"
-          summary: Reference documentation for .NET packaged-provided APIs
-          url: /dotnet/api/?preserve-view=true
         - title: ".NET API reference"
           summary: API reference documentation for .NET
           url: /dotnet/api?view=net-9.0&preserve-view=true

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -361,9 +361,9 @@ additionalContent:
         - title: ".NET Aspire API reference"
           summary: API reference documentation for .NET Aspire
           url: /dotnet/api?view=dotnet-aspire-9.0&preserve-view=true
-        - title: ".NET Platform Extensions API reference"
-          summary: API reference documentation for .NET Platform Extensions
-          url: /dotnet/api?view=dotnet-plat-ext-9.0&preserve-view=true
+        - title: ".NET package-provided API reference"
+          summary: Reference documentation for .NET packaged-provided APIs
+          url: /dotnet/api/?preserve-view=true
         - title: ".NET API reference"
           summary: API reference documentation for .NET
           url: /dotnet/api?view=net-9.0&preserve-view=true


### PR DESCRIPTION
The platform extensions monikers don't exist anymore.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/index.yml](https://github.com/dotnet/docs-aspire/blob/63239aabb4b2416c0ecc5bb0a3fc55fa01562abf/docs/index.yml) | [Limit summary to 400 characters](https://review.learn.microsoft.com/en-us/dotnet/aspire/index?branch=pr-en-us-2480) |

<!-- PREVIEW-TABLE-END -->