### PR TITLE
Add docs for new SQL Project extension feature to use a connection string

### DIFF
--- a/docs/community-toolkit/hosting-sql-database-projects.md
+++ b/docs/community-toolkit/hosting-sql-database-projects.md
@@ -108,6 +108,22 @@ builder.AddSqlProject("mysqlproj")
        .WithReference(sql);
 ```
 
+## Support for existing SQL Server instances
+
+Starting with version 9.2.0, you can publish the SQL Database project to an existing SQL Server instance by using a connection string:
+
+```csharp
+var builder = DistributedApplication.CreateBuilder(args);
+
+// Get an existing SQL Server connection string from the configuration
+var connection = builder.AddConnectionString("Aspire");
+
+builder.AddSqlProject<Projects.SdkProject>("mysqlproj")
+       .WithReference(connection);
+
+builder.Build().Run();
+```
+
 ### Deployment options support
 
 To define options that affect the behavior of package deployment, call the `WithConfigureDacDeployOptions` API:


### PR DESCRIPTION

## Summary

Document new feature in the SQL Database Projects hosting extension that adds support for using a connection string

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/community-toolkit/hosting-sql-database-projects.md](https://github.com/dotnet/docs-aspire/blob/b44713f5be6593bc8c80bd9d8e7f44c5e900be08/docs/community-toolkit/hosting-sql-database-projects.md) | [.NET Aspire SQL Database Projects hosting integration](https://review.learn.microsoft.com/en-us/dotnet/aspire/community-toolkit/hosting-sql-database-projects?branch=pr-en-us-2486) |

<!-- PREVIEW-TABLE-END -->