### PR TITLE
Fix the SQL Server with Entity Framework tutorial

### DIFF
--- a/docs/database/snippets/tutorial/aspiresqlefcore/AspireSQLEFCore/Components/Pages/Home.razor
+++ b/docs/database/snippets/tutorial/aspiresqlefcore/AspireSQLEFCore/Components/Pages/Home.razor
@@ -1,5 +1,6 @@
 ﻿@page "/"
 @inject TicketContext context
+@using Microsoft.EntityFrameworkCore
 
 <div class="row">
     <div class="col-md-6">


### PR DESCRIPTION
## Summary

The razor code in the [Tutorial: Connect an ASP.NET Core app to SQL Server using .NET Aspire and Entity Framework Core](https://learn.microsoft.com/dotnet/aspire/database/sql-server-integrations) currently causes an error. I've added the following line to the snippet to fix it:

``` razor
@using Microsoft.EntityFrameworkCore
```

Fixes #2102
