### PR TITLE
Fixes to the PostgreSQL EF integration article

### DIFF
--- a/docs/database/includes/postgresql-ef-client.md
+++ b/docs/database/includes/postgresql-ef-client.md
@@ -221,4 +221,3 @@ The .NET Aspire PostgreSQL Entity Framework Core integration will emit the follo
   - `ec_Npgsql_connection_pools`
   - `ec_Npgsql_multiplexing_average_commands_per_batch`
   - `ec_Npgsql_multiplexing_average_write_time_per_batch`
-  


### PR DESCRIPTION
## Summary

The `EnrichNpgsqlDBContext()` method doesn't take a `connectionName` parameter so I've removed that. I also thought it wasn't clear that you must call `AddNpgsqlDbContext()` first so I clarified that.

Fixes #2337
