### PR TITLE
List CosmosDB triggers as supported

### DIFF
--- a/docs/serverless/functions.md
+++ b/docs/serverless/functions.md
@@ -46,6 +46,7 @@ The following table lists the supported triggers for Azure Functions in the .NET
 | Azure Service Bus trigger | `ServiceBusTrigger` | [📦 Aspire.Hosting.Azure.ServiceBus](https://www.nuget.org/packages/Aspire.Hosting.Azure.ServiceBus) |
 | Azure Storage Blobs trigger | `BlobTrigger` | [📦 Aspire.Hosting.Azure.Storage](https://www.nuget.org/packages/Aspire.Hosting.Azure.Storage) |
 | Azure Storage Queues trigger | `QueueTrigger` | [📦 Aspire.Hosting.Azure.Storage](https://www.nuget.org/packages/Aspire.Hosting.Azure.Storage) |
+| Azure CosmosDB trigger | `CosmosDbTrigger` | [📦 Aspire.Hosting.Azure.CosmosDB](https://www.nuget.org/packages/Aspire.Hosting.Azure.CosmosDB), Aspire 9.1+ |
 | HTTP trigger | `HttpTrigger` | Supported without any additional resource dependencies. |
 | Timer trigger | `TimerTrigger` | Supported without any additional resource dependencies—relies on implicit host storage. |
 

--- a/docs/serverless/functions.md
+++ b/docs/serverless/functions.md
@@ -46,7 +46,7 @@ The following table lists the supported triggers for Azure Functions in the .NET
 | Azure Service Bus trigger | `ServiceBusTrigger` | [📦 Aspire.Hosting.Azure.ServiceBus](https://www.nuget.org/packages/Aspire.Hosting.Azure.ServiceBus) |
 | Azure Storage Blobs trigger | `BlobTrigger` | [📦 Aspire.Hosting.Azure.Storage](https://www.nuget.org/packages/Aspire.Hosting.Azure.Storage) |
 | Azure Storage Queues trigger | `QueueTrigger` | [📦 Aspire.Hosting.Azure.Storage](https://www.nuget.org/packages/Aspire.Hosting.Azure.Storage) |
-| Azure CosmosDB trigger | `CosmosDbTrigger` | [📦 Aspire.Hosting.Azure.CosmosDB](https://www.nuget.org/packages/Aspire.Hosting.Azure.CosmosDB), Aspire 9.1+ |
+| Azure CosmosDB trigger | `CosmosDbTrigger` | [📦 Aspire.Hosting.Azure.CosmosDB](https://www.nuget.org/packages/Aspire.Hosting.Azure.CosmosDB) |
 | HTTP trigger | `HttpTrigger` | Supported without any additional resource dependencies. |
 | Timer trigger | `TimerTrigger` | Supported without any additional resource dependencies—relies on implicit host storage. |
 


### PR DESCRIPTION
@IEvangelist CosmosDB triggers are going to be supported for Functions as of 9.1.

I dunno how we want to stylize this in the docs but I figured a note in the column is a good enough start.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/serverless/functions.md](https://github.com/dotnet/docs-aspire/blob/db7f697acc11e8307a55df5f2b4c432af2cfb595/docs/serverless/functions.md) | [.NET Aspire Azure Functions integration (Preview)](https://review.learn.microsoft.com/en-us/dotnet/aspire/serverless/functions?branch=pr-en-us-2550) |


<!-- PREVIEW-TABLE-END -->