### PR TITLE
Fix Azurite container ports code example

### DIFF
--- a/docs/storage/azure-storage-blobs-integration.md
+++ b/docs/storage/azure-storage-blobs-integration.md
@@ -23,7 +23,7 @@ In your app host project, register the Azure Blob Storage integration by chainin
 var builder = DistributedApplication.CreateBuilder(args);
 
 var blobs = builder.AddAzureStorage("storage")
-                   .RunAsEmulator();
+                   .RunAsEmulator()
                    .AddBlobs("blobs");
 
 builder.AddProject<Projects.ExampleProject>()

--- a/docs/storage/includes/storage-app-host.md
+++ b/docs/storage/includes/storage-app-host.md
@@ -176,9 +176,9 @@ var builder = DistributedApplication.CreateBuilder(args);
 var storage = builder.AddAzureStorage("storage").RunAsEmulator(
                      azurite =>
                      {
-                         azurite.WithBlobPort("blob", 27000)
-                                .WithQueuePort("queue", 27001)
-                                .WithTablePort("table", 27002);
+                         azurite.WithBlobPort(27000)
+                                .WithQueuePort(27001)
+                                .WithTablePort(27002);
                      });
 
 // After adding all resources, run the app...


### PR DESCRIPTION
Fixes #2553

Update Azurite container ports code example to use only one argument for `WithBlobPort`, `WithTablePort`, and `WithQueuePort`.

* Remove the string arguments representing the type configured from the code example in `docs/storage/azure-storage-blobs-integration.md`.
* Specify only the port numbers for `WithBlobPort`, `WithQueuePort`, and `WithTablePort` in the code example.
* Update the code example in `docs/storage/includes/storage-app-host.md` to reflect the changes.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dotnet/docs-aspire/pull/2554?shareId=8acd9573-509b-4ad2-b4ff-e14f495c5f95).

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/storage/azure-storage-blobs-integration.md](https://github.com/dotnet/docs-aspire/blob/5efeaee4b2eb18a6c299bf07a1fe60fddaba129c/docs/storage/azure-storage-blobs-integration.md) | [.NET Aspire Azure Blob Storage integration](https://review.learn.microsoft.com/en-us/dotnet/aspire/storage/azure-storage-blobs-integration?branch=pr-en-us-2554) |

<!-- PREVIEW-TABLE-END -->