### PR TITLE
Fixes to enrichment section in other EF Core integrations

### DIFF
--- a/docs/database/mysql-entity-framework-integration.md
+++ b/docs/database/mysql-entity-framework-integration.md
@@ -57,13 +57,29 @@ public class ExampleService(ExampleDbContext context)
 
 For more information on dependency injection, see [.NET dependency injection](/dotnet/core/extensions/dependency-injection).
 
-### Add a MySQL database context with enrichment
+### Enrich a MySQL database context
 
-To enrich the `DbContext` with additional services, such as automatic retries, health checks, logging and telemetry, call the <xref:Microsoft.Extensions.Hosting.AspireEFMySqlExtensions.EnrichMySqlDbContext*> method:
+You may prefer to use the standard Entity Framework method to obtain a database context and add it to the dependency injection container:
+
+```csharp
+builder.Services.AddDbContext<ExampleDbContext>(options =>
+    options.UseMySql(builder.Configuration.GetConnectionString("mysqldb")
+        ?? throw new InvalidOperationException("Connection string 'mysqldb' not found.")));
+```
+
+> [!NOTE]
+> The connection string name that you pass to the <xref:Microsoft.Extensions.Configuration.ConfigurationExtensions.GetConnectionString*> method must match the name used when adding the MySQL resource in the app host project. For more information, see [Add MySQL server resource and database resource](#add-mysql-server-resource-and-database-resource).
+
+You have more flexibility when you create the database context in this way, for example:
+
+- You can reuse existing configuration code for the database context without rewriting it for .NET Aspire.
+- You can use Entity Framework Core interceptors to modify database operations.
+- You can choose not to use Entity Framework Core context pooling, which may perform better in some circumstances.
+
+If you use this method, you can enhance the database context with .NET Aspire-style retries, health checks, logging, and telemetry features by calling the <xref:Microsoft.Extensions.Hosting.AspireEFMySqlExtensions.EnrichMySqlDbContext*> method:
 
 ```csharp
 builder.EnrichMySqlDbContext<ExampleDbContext>(
-    connectionName: "mysqldb",
     configureSettings: settings =>
     {
         settings.DisableRetry = false;

--- a/docs/database/oracle-entity-framework-integration.md
+++ b/docs/database/oracle-entity-framework-integration.md
@@ -185,13 +185,29 @@ public class ExampleService(ExampleDbContext context)
 
 For more information on dependency injection, see [.NET dependency injection](/dotnet/core/extensions/dependency-injection).
 
-### Add Oracle database context with enrichment
+### Enrich Oracle database context
 
-To enrich the `DbContext` with additional services, such as automatic retries, health checks, logging and telemetry, call the <xref:Microsoft.Extensions.Hosting.AspireOracleEFCoreExtensions.EnrichOracleDatabaseDbContext*> method:
+You may prefer to use the standard Entity Framework method to obtain a database context and add it to the dependency injection container:
+
+```csharp
+builder.Services.AddDbContext<ExampleDbContext>(options =>
+    options.UseOracle(builder.Configuration.GetConnectionString("oracledb")
+        ?? throw new InvalidOperationException("Connection string 'oracledb' not found.")));
+```
+
+> [!NOTE]
+> The connection string name that you pass to the <xref:Microsoft.Extensions.Configuration.ConfigurationExtensions.GetConnectionString*> method must match the name used when adding the Oracle resource in the app host project. For more information, see [Add Oracle server and database resources](#add-oracle-server-and-database-resources).
+
+You have more flexibility when you create the database context in this way, for example:
+
+- You can reuse existing configuration code for the database context without rewriting it for .NET Aspire.
+- You can use Entity Framework Core interceptors to modify database operations.
+- You can choose not to use Entity Framework Core context pooling, which may perform better in some circumstances.
+
+If you use this method, you can enhance the database context with .NET Aspire-style retries, health checks, logging, and telemetry features by calling the <xref:Microsoft.Extensions.Hosting.AspireOracleEFCoreExtensions.EnrichOracleDatabaseDbContext*> method:
 
 ```csharp
 builder.EnrichOracleDatabaseDbContext<ExampleDbContext>(
-    connectionName: "oracledb",
     configureSettings: settings =>
     {
         settings.DisableRetry = false;

--- a/docs/database/sql-server-entity-framework-integration.md
+++ b/docs/database/sql-server-entity-framework-integration.md
@@ -64,13 +64,29 @@ public class ExampleService(ExampleDbContext context)
 
 For more information on dependency injection, see [.NET dependency injection](/dotnet/core/extensions/dependency-injection).
 
-### Add SQL Server database context with enrichment
+### Enrich a SQL Server database context
 
-To enrich the `DbContext` with additional services, such as automatic retries, health checks, logging and telemetry, call the <xref:Microsoft.Extensions.Hosting.AspireSqlServerEFCoreSqlClientExtensions.EnrichSqlServerDbContext*> method:
+You may prefer to use the standard Entity Framework method to obtain a database context and add it to the dependency injection container:
+
+```csharp
+builder.Services.AddDbContext<ExampleDbContext>(options =>
+    options.UseSqlServer(builder.Configuration.GetConnectionString("database")
+        ?? throw new InvalidOperationException("Connection string 'database' not found.")));
+```
+
+> [!NOTE]
+> The connection string name that you pass to the <xref:Microsoft.Extensions.Configuration.ConfigurationExtensions.GetConnectionString*> method must match the name used when adding the SQL server resource in the app host project. For more information, see [Add SQL Server resource and database resource](#add-sql-server-resource-and-database-resource).
+
+You have more flexibility when you create the database context in this way, for example:
+
+- You can reuse existing configuration code for the database context without rewriting it for .NET Aspire.
+- You can use Entity Framework Core interceptors to modify database operations.
+- You can choose not to use Entity Framework Core context pooling, which may perform better in some circumstances.
+
+If you use this method, you can enhance the database context with .NET Aspire-style retries, health checks, logging, and telemetry features by calling the <xref:Microsoft.Extensions.Hosting.AspireSqlServerEFCoreSqlClientExtensions.EnrichSqlServerDbContext*> method:
 
 ```csharp
 builder.EnrichSqlServerDbContext<ExampleDbContext>(
-    connectionName: "database",
     configureSettings: settings =>
     {
         settings.DisableRetry = false;


### PR DESCRIPTION
## Summary

We've recently updated the EF DBContext enrichment section for the PostgreSQL EF integration. This PR propagates those changes to other EF Core integrations:

- SQL Server
- Oracle
- MySQL Pomelo