### PR TITLE
Resource notifications

### DIFF
--- a/docs/testing/accessing-resources.md
+++ b/docs/testing/accessing-resources.md
@@ -1,7 +1,7 @@
 ---
 title: Access resources in .NET Aspire tests
 description: Learn how to access the resources from the .NET Aspire app host in your tests.
-ms.date: 10/21/2024
+ms.date: 02/11/2025
 zone_pivot_groups: unit-testing-framework
 ---
 
@@ -11,7 +11,7 @@ In this article, you'll learn how to access the resources from the .NET Aspire a
 
 ## Access HTTP resources
 
-To access an HTTP resource, use the <xref:System.Net.Http.HttpClient> to request and receive responses. The <xref:Aspire.Hosting.DistributedApplication> and the <xref:Aspire.Hosting.Testing.DistributedApplicationFactory> both provide a `CreateHttpClient` method that's used to create an `HttpClient` instance for a specific resource, based on the resource name from the app host. This method also takes an optional `endpointName` parameter, so if the resource has multiple endpoints, you can specify which one to use.
+To access an HTTP resource, use the <xref:System.Net.Http.HttpClient> to request and receive responses. The <xref:Aspire.Hosting.DistributedApplication> and the <xref:Aspire.Hosting.Testing.DistributedApplicationFactory> both provide a <xref:Aspire.Hosting.Testing.DistributedApplicationFactory.CreateHttpClient*> method that's used to create an `HttpClient` instance for a specific resource, based on the resource name from the app host. This method also takes an optional `endpointName` parameter, so if the resource has multiple endpoints, you can specify which one to use.
 
 ## Access other resources
 
@@ -19,7 +19,7 @@ In a test, you might want to access other resources by the connection informatio
 
 ## Ensure resources are available
 
-Starting with .NET Aspire 9, there's support for waiting on dependent resources to be available (via the [health check](../fundamentals/health-checks.md) mechanism). This is useful in tests that ensure a resource is available before attempting to access it. The <xref:Aspire.Hosting.ApplicationModel.ResourceNotificationService> class provides a <xref:Aspire.Hosting.ApplicationModel.ResourceNotificationService.WaitForResourceAsync*?displayProperty=nameWithType> method that's used to wait for a named resource to be available. This method takes the resource name and the desired state of the resource as parameters and returns a `Task` that yields back when the resource is available. You can access the <xref:Aspire.Hosting.ApplicationModel.ResourceNotificationService> via <xref:Aspire.Hosting.DistributedApplication.ResourceNotifications?displayProperty=nameWithType>, as in the following example.
+Starting with .NET Aspire 9, there's support for waiting on dependent resources to be available (via the [health check](../fundamentals/health-checks.md) mechanism). This is useful in tests that ensure a resource is available before attempting to access it. The <xref:Aspire.Hosting.ApplicationModel.ResourceNotificationService> class provides a <xref:Aspire.Hosting.ApplicationModel.ResourceNotificationService.WaitForResourceAsync*?displayProperty=nameWithType> method that's used to wait for a named resource to be available. This method takes the resource name and the desired state of the resource as parameters and returns a <xref:System.Threading.Tasks.Task> that yields back when the resource is available. You can access the <xref:Aspire.Hosting.ApplicationModel.ResourceNotificationService> via <xref:Aspire.Hosting.DistributedApplication.ResourceNotifications?displayProperty=nameWithType>, as in the following example.
 
 > [!NOTE]
 > It's recommended to provide a timeout when waiting for resources, to prevent the test from hanging indefinitely in situations where a resource never becomes available.
@@ -32,7 +32,7 @@ await app.ResourceNotifications.WaitForResourceAsync(
         cts.Token); 
 ```
 
-A resource enters the "Running" state as soon as it starts executing, but this does not mean that it is ready to serve requests. If you want to wait for the resource to be ready to serve requests, and your resource has health checks, you can wait for the resource to become healthy by using the <xref:Aspire.Hosting.ApplicationModel.ResourceNotificationService.WaitForResourceHealthyAsync*?displayProperty=nameWithType> method.
+A resource enters the <xref:Aspire.Hosting.ApplicationModel.KnownResourceStates.Running?displayProperty=nameWithType> state as soon as it starts executing, but this does not mean that it is ready to serve requests. If you want to wait for the resource to be ready to serve requests, and your resource has health checks, you can wait for the resource to become healthy by using the <xref:Aspire.Hosting.ApplicationModel.ResourceNotificationService.WaitForResourceHealthyAsync*?displayProperty=nameWithType> method.
 
 ```csharp
 using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));


### PR DESCRIPTION
## Summary

Resource notifications.

Supersedes and closes #2564, and fixes #2563.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/testing/accessing-resources.md](https://github.com/dotnet/docs-aspire/blob/106c89b4d6acafe4d820d9bde928bac8e0bf968e/docs/testing/accessing-resources.md) | [Access resources in .NET Aspire tests](https://review.learn.microsoft.com/en-us/dotnet/aspire/testing/accessing-resources?branch=pr-en-us-2568) |

<!-- PREVIEW-TABLE-END -->