### PR TITLE
Add Meter name to Kafka Metrics

### DIFF
--- a/docs/messaging/kafka-integration.md
+++ b/docs/messaging/kafka-integration.md
@@ -334,14 +334,15 @@ The .NET Aspire Apache Kafka integration dos not emit distributed traces.
 
 The .NET Aspire Apache Kafka integration emits the following metrics using OpenTelemetry:
 
-- `messaging.kafka.network.tx`
-- `messaging.kafka.network.transmitted`
-- `messaging.kafka.network.rx`
-- `messaging.kafka.network.received`
-- `messaging.publish.messages`
-- `messaging.kafka.message.transmitted`
-- `messaging.receive.messages`
-- `messaging.kafka.message.received`
+- `Aspire.Confluent.Kafka`
+    - `messaging.kafka.network.tx`
+    - `messaging.kafka.network.transmitted`
+    - `messaging.kafka.network.rx`
+    - `messaging.kafka.network.received`
+    - `messaging.publish.messages`
+    - `messaging.kafka.message.transmitted`
+    - `messaging.receive.messages`
+    - `messaging.kafka.message.received`
 
 ## See also
 


### PR DESCRIPTION
## Summary

Add meter name to kafka metrics - similar to how https://learn.microsoft.com/en-us/dotnet/aspire/database/sql-server-integration?tabs=dotnet-cli%2Cssms#metrics does it.

Meter name source: https://github.com/dotnet/aspire/blob/a1136f86f29da15e5dfa07f05eacbd91226898c5/src/Components/Aspire.Confluent.Kafka/ConfluentKafkaCommon.cs#L8


