### PR TITLE
Remove-azure-features-from-devcontainer

### DIFF
--- a/docs/get-started/github-codespaces.md
+++ b/docs/get-started/github-codespaces.md
@@ -150,7 +150,6 @@ And use this instead of the hardcoded JSON below:
         "vscode": {
             "extensions": [
                 "ms-dotnettools.csdevkit",
-                "ms-azuretools.vscode-bicep",
                 "GitHub.copilot-chat",
                 "GitHub.copilot"
             ]

--- a/docs/get-started/github-codespaces.md
+++ b/docs/get-started/github-codespaces.md
@@ -124,10 +124,8 @@ And use this instead of the hardcoded JSON below:
     // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
     "image": "mcr.microsoft.com/devcontainers/dotnet:9.0-bookworm",
     "features": {
-        "ghcr.io/devcontainers/features/azure-cli:1": {},
         "ghcr.io/devcontainers/features/docker-in-docker:2": {},
-        "ghcr.io/devcontainers/features/powershell:1": {},
-        "ghcr.io/azure/azure-dev/azd:0": {}
+        "ghcr.io/devcontainers/features/powershell:1": {}
     },
 
     "hostRequirements": {
@@ -153,7 +151,6 @@ And use this instead of the hardcoded JSON below:
             "extensions": [
                 "ms-dotnettools.csdevkit",
                 "ms-azuretools.vscode-bicep",
-                "ms-azuretools.azure-dev",
                 "GitHub.copilot-chat",
                 "GitHub.copilot"
             ]


### PR DESCRIPTION
## Summary

Remove the Azure features out of the devcontainer sample.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/get-started/github-codespaces.md](https://github.com/dotnet/docs-aspire/blob/5da14ed6b64083beb08be99011bcfb553ecef64e/docs/get-started/github-codespaces.md) | [.NET Aspire and GitHub Codespaces](https://review.learn.microsoft.com/en-us/dotnet/aspire/get-started/github-codespaces?branch=pr-en-us-2664) |


<!-- PREVIEW-TABLE-END -->