### PR TITLE
Move Upgrade to 9.1 to the top

### DIFF
--- a/docs/whats-new/dotnet-aspire-9.1.md
+++ b/docs/whats-new/dotnet-aspire-9.1.md
@@ -23,13 +23,6 @@ For more information on the official .NET version and .NET Aspire version suppor
 - [.NET support policy](https://dotnet.microsoft.com/platform/support/policy): Definitions for LTS and STS.
 - [.NET Aspire support policy](https://dotnet.microsoft.com/platform/support/policy/aspire): Important unique product life cycle details.
 
-## Improved onboarding experience
-
-The onboarding experience for .NET Aspire is improved with 9.1. The team worked on creating a GitHub Codespaces template that installs all the necessary dependencies for .NET Aspire, making it easier to get started, including the templates and the ASP.NET Core developer certificate. Additionally, there's support for Dev Containers. For more information, see:
-
-- [.NET Aspire and GitHub Codespaces](../get-started/github-codespaces.md)
-- [.NET Aspire and Visual Studio Code Dev Containers](../get-started/dev-containers.md)
-
 ## Upgrade to .NET Aspire 9.1
 
 Moving between minor releases of .NET Aspire is simple:
@@ -57,6 +50,13 @@ Moving between minor releases of .NET Aspire is simple:
     > The `dotnet new update` command updates all of your templates to the latest version.
 
 If your app host project file doesn't have the `Aspire.AppHost.Sdk` reference, you might still be using .NET Aspire 8. To upgrade to 9.1, you can follow [the documentation from last release](../get-started/upgrade-to-aspire-9).
+
+## Improved onboarding experience
+
+The onboarding experience for .NET Aspire is improved with 9.1. The team worked on creating a GitHub Codespaces template that installs all the necessary dependencies for .NET Aspire, making it easier to get started, including the templates and the ASP.NET Core developer certificate. Additionally, there's support for Dev Containers. For more information, see:
+
+- [.NET Aspire and GitHub Codespaces](../get-started/github-codespaces.md)
+- [.NET Aspire and Visual Studio Code Dev Containers](../get-started/dev-containers.md)
 
 ## Dashboard UX and customization
 


### PR DESCRIPTION
The "Upgrade to 9.1" should be first

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/whats-new/dotnet-aspire-9.1.md](https://github.com/dotnet/docs-aspire/blob/79ee417c535a4d0c8d58d372c1ef3f6418038152/docs/whats-new/dotnet-aspire-9.1.md) | [What's new in .NET Aspire 9.1](https://review.learn.microsoft.com/en-us/dotnet/aspire/whats-new/dotnet-aspire-9.1?branch=pr-en-us-2668) |

<!-- PREVIEW-TABLE-END -->