### PR TITLE
Fix for Orleans example code: silo is not marked dead on graceful shutdown

### DIFF
--- a/docs/frameworks/snippets/Orleans/OrleansServer/Program.cs
+++ b/docs/frameworks/snippets/Orleans/OrleansServer/Program.cs
@@ -6,7 +6,7 @@ var builder = WebApplication.CreateBuilder(args);
 builder.AddServiceDefaults();
 builder.AddKeyedAzureTableClient("clustering");
 builder.AddKeyedAzureBlobClient("grain-state");
-builder.UseOrleans();
+builder.Host.UseOrleans();
 
 var app = builder.Build();
 


### PR DESCRIPTION
The silo lifecycle was not tied to the host lifecycle, resulting in silo not marked dead when e.g. deploying a new revision to Azure Container Apps, which in turn results in startup errors in the new revision.

`builder.Host.UseOrleans()` is consistently used in other Orleans examples as a best practice