### PR TITLE
Add snippet on difference between different existing resource strategies

### DIFF
--- a/docs/azure/integrations-overview.md
+++ b/docs/azure/integrations-overview.md
@@ -105,6 +105,8 @@ You can query whether a resource is marked as an existing resource, by calling t
 
 .NET Aspire provides support for referencing existing Azure resources. You mark an existing resource through the `PublishAsExisting`, `RunAsExisting`, and `AsExisting` APIs. These APIs allow developers to reference already-deployed Azure resources, configure them, and generate appropriate deployment manifests using Bicep templates.
 
+Existing resources referenced with these APIs can be enhanced with role assignments and other customizations that are available via Aspire's [infrastructure as code capabailities](#infrastructure-as-code). These APIs are limited to Azure resources that can be deployed with Bicep templates.
+
 ### Configure existing Azure resources for run mode
 
 The `RunAsExisting` method is used when a distributed application is executing in "run" mode. In this mode, it assumes that the referenced Azure resource already exists and integrates with it during execution without provisioning the resource. To mark an Azure resource as existing, call the `RunAsExisting` method on the resource builder. Consider the following example:
@@ -217,7 +219,7 @@ For more information on the generated Bicep template, see [Infrastructure as cod
 > [!WARNING]
 > When interacting with existing resources that require authentication, ensure the authentication strategy that you're configuring in the .NET Aspire application model aligns with the authentication strategy allowed by the existing resource. For example, it's not possible to use managed identity against an existing Azure PostgreSQL resource that isn't configured to allow managed identity. Similarly, if an existing Azure Redis resource disabled access keys, it's not possible to use access key authentication.
 
-### Configure existing Azure resources
+### Configure existing Azure resources in all modes
 
 The `AsExisting` method is used when the distributed application is running in "run" or "publish" mode. Because the `AsExisting` method operates in both scenarios, it only supports a parameterized reference to the resource name or resource group name. This approach helps prevent the use of the same resource in both testing and production environments.
 
@@ -273,6 +275,9 @@ The preceding code:
 - The `api` project references the `storage` resource regardless of the mode.
 
 The consuming API project uses the connection string information with no knowledge of how the app host configured it. In "publish" mode, the code adds a new Azure Storage resource—which would be reflected in the [deployment manifest](../deployment/manifest-format.md) accordingly. When in "run" mode the connection string corresponds to a configuration value visible to the app host. It's assumed that all role assignments for the target resource are configured. This means, you'd likely configure an environment variable or a user secret to store the connection string. The configuration is resolved from the `ConnectionStrings__storage` (or `ConnectionStrings:storage`) configuration key. These configuration values can be viewed when the app runs. For more information, see [Resource details](../fundamentals/dashboard/explore.md#resource-details).
+
+Unlike existing resources modeled with [the first-class `AsExisting` API](#use-existing-azure-resources), existing resource modeled as connection strings cannot be enhanced with additional role assignments or infrastructure customizations.
+
 
 ## Infrastructure as code
 

--- a/docs/azure/integrations-overview.md
+++ b/docs/azure/integrations-overview.md
@@ -278,7 +278,6 @@ The consuming API project uses the connection string information with no knowled
 
 Unlike existing resources modeled with [the first-class `AsExisting` API](#use-existing-azure-resources), existing resource modeled as connection strings cannot be enhanced with additional role assignments or infrastructure customizations.
 
-
 ## Infrastructure as code
 
 The Azure SDK for .NET provides the [📦 Azure.Provisioning](https://www.nuget.org/packages/Azure.Provisioning) NuGet package and a suite of service-specific [Azure provisioning packages](https://www.nuget.org/packages?q=owner%3A+azure-sdk+description%3A+declarative+resource+provisioning&sortby=relevance). These Azure provisioning libraries make it easy to declaratively specify Azure infrastructure natively in .NET. Their APIs enable you to write object-oriented infrastructure in C#, resulting in Bicep. [Bicep is a domain-specific language (DSL)](/azure/azure-resource-manager/bicep/overview) for deploying Azure resources declaratively.

--- a/docs/azure/integrations-overview.md
+++ b/docs/azure/integrations-overview.md
@@ -105,7 +105,7 @@ You can query whether a resource is marked as an existing resource, by calling t
 
 .NET Aspire provides support for referencing existing Azure resources. You mark an existing resource through the `PublishAsExisting`, `RunAsExisting`, and `AsExisting` APIs. These APIs allow developers to reference already-deployed Azure resources, configure them, and generate appropriate deployment manifests using Bicep templates.
 
-Existing resources referenced with these APIs can be enhanced with role assignments and other customizations that are available via Aspire's [infrastructure as code capabailities](#infrastructure-as-code). These APIs are limited to Azure resources that can be deployed with Bicep templates.
+Existing resources referenced with these APIs can be enhanced with role assignments and other customizations that are available with .NET Aspire's [infrastructure as code capabilities](#infrastructure-as-code). These APIs are limited to Azure resources that can be deployed with Bicep templates.
 
 ### Configure existing Azure resources for run mode
 


### PR DESCRIPTION
Adding some additional clarification on the difference between the different strategies for referencing existing Azure resources in the `docs/azure/integrations-overview.md` file.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/azure/integrations-overview.md](https://github.com/dotnet/docs-aspire/blob/bbafa657fedf333dd6a758790051e4d9aead03bc/docs/azure/integrations-overview.md) | [.NET Aspire Azure integrations overview](https://review.learn.microsoft.com/en-us/dotnet/aspire/azure/integrations-overview?branch=pr-en-us-2678) |


<!-- PREVIEW-TABLE-END -->