### PR TITLE
Update testing snippets to use v9.1 testing changes

### DIFF
--- a/docs/testing/snippets/testing/mstest/AspireApp.Tests/EnvVarTests.cs
+++ b/docs/testing/snippets/testing/mstest/AspireApp.Tests/EnvVarTests.cs
@@ -9,14 +9,13 @@ public class EnvVarTests
     public async Task WebResourceEnvVarsResolveToApiService()
     {
         // Arrange
-        var appHost = await DistributedApplicationTestingBuilder
+        var builder = await DistributedApplicationTestingBuilder
             .CreateAsync<Projects.AspireApp_AppHost>();
 
-        var frontend = (IResourceWithEnvironment)appHost.Resources
-            .Single(static r => r.Name == "webfrontend");
+        var frontend = builder.CreateResourceBuilder<ProjectResource>("webfrontend");
 
         // Act
-        var envVars = await frontend.GetEnvironmentVariableValuesAsync(
+        var envVars = await frontend.Resource.GetEnvironmentVariableValuesAsync(
             DistributedApplicationOperation.Publish);
 
         // Assert

--- a/docs/testing/snippets/testing/mstest/AspireApp.Tests/IntegrationTest1.cs
+++ b/docs/testing/snippets/testing/mstest/AspireApp.Tests/IntegrationTest1.cs
@@ -7,29 +7,25 @@ public class IntegrationTest1
     public async Task GetWebResourceRootReturnsOkStatusCode()
     {
         // Arrange
-        var appHost = await DistributedApplicationTestingBuilder
+        var builder = await DistributedApplicationTestingBuilder
             .CreateAsync<Projects.AspireApp_AppHost>();
 
-        appHost.Services.ConfigureHttpClientDefaults(clientBuilder =>
+        builder.Services.ConfigureHttpClientDefaults(clientBuilder =>
         {
             clientBuilder.AddStandardResilienceHandler();
         });
 
-        await using var app = await appHost.BuildAsync();
-
-        var resourceNotificationService = app.Services
-            .GetRequiredService<ResourceNotificationService>();
+        await using var app = await builder.BuildAsync();
 
         await app.StartAsync();
 
         // Act
         var httpClient = app.CreateHttpClient("webfrontend");
 
-        await resourceNotificationService.WaitForResourceAsync(
-                "webfrontend",
-                KnownResourceStates.Running
-            )
-            .WaitAsync(TimeSpan.FromSeconds(30));
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await app.ResourceNotifications.WaitForResourceHealthyAsync(
+            "webfrontend",
+            cts.Token);
         
         var response = await httpClient.GetAsync("/");
 

--- a/docs/testing/snippets/testing/nunit/AspireApp.Tests/EnvVarTests.cs
+++ b/docs/testing/snippets/testing/nunit/AspireApp.Tests/EnvVarTests.cs
@@ -8,14 +8,13 @@ public class EnvVarTests
     public async Task WebResourceEnvVarsResolveToApiService()
     {
         // Arrange
-        var appHost = await DistributedApplicationTestingBuilder
+        var builder = await DistributedApplicationTestingBuilder
             .CreateAsync<Projects.AspireApp_AppHost>();
 
-        var frontend = (IResourceWithEnvironment)appHost.Resources
-            .Single(static r => r.Name == "webfrontend");
+        var frontend = builder.CreateResourceBuilder<ProjectResource>("webfrontend");
 
         // Act
-        var envVars = await frontend.GetEnvironmentVariableValuesAsync(
+        var envVars = await frontend.Resource.GetEnvironmentVariableValuesAsync(
             DistributedApplicationOperation.Publish);
 
         // Assert

--- a/docs/testing/snippets/testing/nunit/AspireApp.Tests/IntegrationTest1.cs
+++ b/docs/testing/snippets/testing/nunit/AspireApp.Tests/IntegrationTest1.cs
@@ -6,29 +6,25 @@ public class IntegrationTest1
     public async Task GetWebResourceRootReturnsOkStatusCode()
     {
         // Arrange
-        var appHost = await DistributedApplicationTestingBuilder
+        var builder = await DistributedApplicationTestingBuilder
             .CreateAsync<Projects.AspireApp_AppHost>();
 
-        appHost.Services.ConfigureHttpClientDefaults(clientBuilder =>
+        builder.Services.ConfigureHttpClientDefaults(clientBuilder =>
         {
             clientBuilder.AddStandardResilienceHandler();
         });
 
-        await using var app = await appHost.BuildAsync();
-
-        var resourceNotificationService = app.Services
-            .GetRequiredService<ResourceNotificationService>();
+        await using var app = await builder.BuildAsync();
 
         await app.StartAsync();
 
         // Act
         var httpClient = app.CreateHttpClient("webfrontend");
 
-        await resourceNotificationService.WaitForResourceAsync(
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await app.ResourceNotifications.WaitForResourceHealthyAsync(
                 "webfrontend",
-                KnownResourceStates.Running
-            )
-            .WaitAsync(TimeSpan.FromSeconds(30));
+                cts.Token);
         
         var response = await httpClient.GetAsync("/");
 

--- a/docs/testing/snippets/testing/xunit/AspireApp.Tests/EnvVarTests.cs
+++ b/docs/testing/snippets/testing/xunit/AspireApp.Tests/EnvVarTests.cs
@@ -8,14 +8,13 @@ public class EnvVarTests
     public async Task WebResourceEnvVarsResolveToApiService()
     {
         // Arrange
-        var appHost = await DistributedApplicationTestingBuilder
+        var builder = await DistributedApplicationTestingBuilder
             .CreateAsync<Projects.AspireApp_AppHost>();
 
-        var frontend = (IResourceWithEnvironment)appHost.Resources
-            .Single(static r => r.Name == "webfrontend");
+        var frontend = builder.CreateResourceBuilder<ProjectResource>("webfrontend");
 
         // Act
-        var envVars = await frontend.GetEnvironmentVariableValuesAsync(
+        var envVars = await frontend.Resource.GetEnvironmentVariableValuesAsync(
             DistributedApplicationOperation.Publish);
 
         // Assert


### PR DESCRIPTION
- Rename appHost to builder
- Use CreateResourceBuilder instead of Resources.Single(...)
- Use ResourceNotifications and WaitForResourceHealthyAsync