### PR TITLE
Update Program.ConfigurePostgresSQLInfra.cs

### DIFF
--- a/docs/snippets/azure/AppHost/Program.ConfigurePostgresSQLInfra.cs
+++ b/docs/snippets/azure/AppHost/Program.ConfigurePostgresSQLInfra.cs
@@ -5,7 +5,7 @@ internal static partial class Program
     public static void ConfigurePostgreSQLInfra(IDistributedApplicationBuilder builder)
     {
         // <configure>
-        builder.AddAzureCosmosDB("cosmos-db")
+        builder.AddAzurePostgresFlexibleServer("postgres")
             .ConfigureInfrastructure(infra =>
             {
                 var flexibleServer = infra.GetProvisionableResources()


### PR DESCRIPTION
## Summary

Correct leading call to `AddAzureCosmosDB` to `AddAzurePostgresFlexibleServer` in `Program.ConfigurePostgreSQLInfra` to provision Azure Postgres.

Fixes #2782
