### PR TITLE
missing a semicolon  in sql-server-entity-framework-integration.md

### DIFF
--- a/docs/database/sql-server-entity-framework-integration.md
+++ b/docs/database/sql-server-entity-framework-integration.md
@@ -90,7 +90,7 @@ builder.EnrichSqlServerDbContext<ExampleDbContext>(
     configureSettings: settings =>
     {
         settings.DisableRetry = false;
-        settings.CommandTimeout = 30 // seconds
+        settings.CommandTimeout = 30; // seconds
     });
 ```
 


### PR DESCRIPTION
## Summary

add a semicolon.

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/database/sql-server-entity-framework-integration.md](https://github.com/dotnet/docs-aspire/blob/2866185d91c1cd7bfbc2e0623b3689709194e4e7/docs/database/sql-server-entity-framework-integration.md) | [.NET Aspire SQL Server Entity Framework Core integration](https://review.learn.microsoft.com/en-us/dotnet/aspire/database/sql-server-entity-framework-integration?branch=pr-en-us-2841) |

<!-- PREVIEW-TABLE-END -->