### PR TITLE
Fix error in Aspire service bus configuration section

### DIFF
--- a/docs/messaging/azure-service-bus-integration.md
+++ b/docs/messaging/azure-service-bus-integration.md
@@ -229,7 +229,7 @@ The preceding code configures the Service Bus emulator container's existing `emu
 
 ##### Configure Service Bus emulator container JSON configuration
 
-The Service Bus emulator container runs with a default [_config.json_](https://github.com/Azure/azure-service-bus-emulator-installer/blob/main/ServiceBus-Emulator/Config/Config.json) file. You can override this file entirely, or update the JSON configuration with a <xref:System.Text.Json.Nodes.JsonNode> representation of the configuration.
+The Service Bus emulator automatically generates a configration similar to this [_config.json_](https://github.com/Azure/azure-service-bus-emulator-installer/blob/main/ServiceBus-Emulator/Config/Config.json) file from the configured resources. You can override this generated file entirely, or update the JSON configuration with a <xref:System.Text.Json.Nodes.JsonNode> representation of the configuration.
 
 To provide a custom JSON configuration file, call the <xref:Aspire.Hosting.AzureServiceBusExtensions.WithConfigurationFile(Aspire.Hosting.ApplicationModel.IResourceBuilder{Aspire.Hosting.Azure.AzureServiceBusEmulatorResource},System.String)> method:
 


### PR DESCRIPTION
The Aspire emulator support doesn't generate this file by default. It uses the registered resources (queues, topics, ...). But it can be set manually.



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/messaging/azure-service-bus-integration.md](https://github.com/dotnet/docs-aspire/blob/a7d582a15924d8cedfbb3fc79032e0616077f1eb/docs/messaging/azure-service-bus-integration.md) | [.NET Aspire Azure Service Bus integration](https://review.learn.microsoft.com/en-us/dotnet/aspire/messaging/azure-service-bus-integration?branch=pr-en-us-2848) |

<!-- PREVIEW-TABLE-END -->