### PR TITLE
Update stackexchange-redis-distributed-caching-integration.md

### DIFF
--- a/docs/caching/stackexchange-redis-distributed-caching-integration.md
+++ b/docs/caching/stackexchange-redis-distributed-caching-integration.md
@@ -156,7 +156,8 @@ You can also set up the [ConfigurationOptions](https://stackexchange.github.io/S
 ```csharp
 builder.AddRedisDistributedCache(
     "cache",
-    static settings => settings.ConnectTimeout = 3_000);
+     null,
+     static options => options.ConnectTimeout = 3_000);
 ```
 
 [!INCLUDE [redis-distributed-client-health-checks-and-diagnostics](includes/redis-distributed-client-health-checks-and-diagnostics.md)]


### PR DESCRIPTION
## Summary
The `ConnnectTimeout` setting is under the options parameter




<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/caching/stackexchange-redis-distributed-caching-integration.md](https://github.com/dotnet/docs-aspire/blob/54219c8c72e88ad1b6025378c19cb0dcf24c0624/docs/caching/stackexchange-redis-distributed-caching-integration.md) | [.NET Aspire Redis&reg;<sup>**[*](#registered)**</sup> distributed caching integration](https://review.learn.microsoft.com/en-us/dotnet/aspire/caching/stackexchange-redis-distributed-caching-integration?branch=pr-en-us-2885) |

<!-- PREVIEW-TABLE-END -->