### PR TITLE
fix typos entity-framework-core-integration-overview

### DIFF
--- a/docs/database/entity-framework-core-integration-overview.md
+++ b/docs/database/entity-framework-core-integration-overview.md
@@ -179,40 +179,44 @@ Alternatively, you can add a context to the DI container using the standard EF C
 :::zone pivot="sql-server-ef"
 
 ```csharp
-builder.Services.AddDbContextPool<ExampleDbContext>(options =>
+builder.Services.AddDbContextPool<ExampleDbContext>(options => {
     var connectionString = builder.Configuration.GetConnectionString("database")
         ?? throw new InvalidOperationException("Connection string 'database' not found.");
-    options.UseSqlServer(connectionString));
+    options.UseSqlServer(connectionString);
+});
 ```
 
 :::zone-end
 :::zone pivot="postgresql-ef"
 
 ```csharp
-builder.Services.AddDbContextPool<ExampleDbContext>(options =>
+builder.Services.AddDbContextPool<ExampleDbContext>(options => {
     var connectionString = builder.Configuration.GetConnectionString("database")
         ?? throw new InvalidOperationException("Connection string 'database' not found.");
-    options.UseNpgsql(connectionString));
+    options.UseNpgsql(connectionString);
+});
 ```
 
 :::zone-end
 :::zone pivot="oracle-ef"
 
 ```csharp
-builder.Services.AddDbContextPool<ExampleDbContext>(options =>
+builder.Services.AddDbContextPool<ExampleDbContext>(options => {
     var connectionString = builder.Configuration.GetConnectionString("database")
         ?? throw new InvalidOperationException("Connection string 'database' not found.");
-    options.UseOracle(connectionString));
+    options.UseOracle(connectionString);
+});
 ```
 
 :::zone-end
 :::zone pivot="mysql-ef"
 
 ```csharp
-builder.Services.AddDbContextPool<ExampleDbContext>(options =>
+builder.Services.AddDbContextPool<ExampleDbContext>(options => {
     var connectionString = builder.Configuration.GetConnectionString("database")
         ?? throw new InvalidOperationException("Connection string 'database' not found.");
-    options.UseMySql(connectionString));
+    options.UseMySql(connectionString);
+});
 ```
 
 :::zone-end
@@ -244,7 +248,7 @@ builder.EnrichSqlServerDbContext<ExampleDbContext>(
     configureSettings: settings =>
     {
         settings.DisableRetry = false;
-        settings.CommandTimeout = 30 // seconds
+        settings.CommandTimeout = 30; // seconds
     });
 ```
 
@@ -256,7 +260,7 @@ builder.EnrichNpgsqlDbContext<ExampleDbContext>(
     configureSettings: settings =>
     {
         settings.DisableRetry = false;
-        settings.CommandTimeout = 30 // seconds
+        settings.CommandTimeout = 30; // seconds
     });
 ```
 
@@ -268,7 +272,7 @@ builder.EnrichOracleDatabaseDbContext<ExampleDbContext>(
     configureSettings: settings =>
     {
         settings.DisableRetry = false;
-        settings.CommandTimeout = 30 // seconds
+        settings.CommandTimeout = 30; // seconds
     });
 ```
 
@@ -280,7 +284,7 @@ builder.EnrichMySqlDbContext<ExampleDbContext>(
     configureSettings: settings =>
     {
         settings.DisableRetry = false;
-        settings.CommandTimeout = 30 // seconds
+        settings.CommandTimeout = 30; // seconds
     });
 ```
 
@@ -314,7 +318,7 @@ builder.EnrichSqlServerDbContext<ExampleDbContext>(
     configureSettings: settings =>
     {
         settings.DisableRetry = false;
-        settings.CommandTimeout = 30 // seconds
+        settings.CommandTimeout = 30; // seconds
     });
 ```
 
@@ -332,7 +336,7 @@ builder.EnrichNpgsqlDbContext<ExampleDbContext>(
     configureSettings: settings =>
     {
         settings.DisableRetry = false;
-        settings.CommandTimeout = 30 // seconds
+        settings.CommandTimeout = 30; // seconds
     });
 ```
 
@@ -350,7 +354,7 @@ builder.EnrichOracleDatabaseDbContext<ExampleDbContext>(
     configureSettings: settings =>
     {
         settings.DisableRetry = false;
-        settings.CommandTimeout = 30 // seconds
+        settings.CommandTimeout = 30; // seconds
     });
 ```
 
@@ -368,7 +372,7 @@ builder.EnrichMySqlDbContext<ExampleDbContext>(
     configureSettings: settings =>
     {
         settings.DisableRetry = false;
-        settings.CommandTimeout = 30 // seconds
+        settings.CommandTimeout = 30; // seconds
     });
 ```
 
@@ -392,7 +396,7 @@ For these requirements, you can use code to formulate a **dynamic connection str
 var connectionStringWithPlaceHolder = builder.Configuration.GetConnectionString("database")
     ?? throw new InvalidOperationException("Connection string 'database' not found.");
 
-connectionString = connectionStringWithPlaceHolder.Replace("{DatabaseName}", "ContosoDatabase");
+var connectionString = connectionStringWithPlaceHolder.Replace("{DatabaseName}", "ContosoDatabase");
 
 builder.Services.AddDbContext<ExampleDbContext>(options =>
     options.UseSqlServer(connectionString
@@ -402,7 +406,7 @@ builder.EnrichSqlServerDbContext<ExampleDbContext>(
     configureSettings: settings =>
     {
         settings.DisableRetry = false;
-        settings.CommandTimeout = 30 // seconds
+        settings.CommandTimeout = 30; // seconds
     });
 ```
 
@@ -413,7 +417,7 @@ builder.EnrichSqlServerDbContext<ExampleDbContext>(
 var connectionStringWithPlaceHolder = builder.Configuration.GetConnectionString("database")
     throw new InvalidOperationException("Connection string 'database' not found.");
 
-connectionString = connectionStringWithPlaceHolder.Replace("{DatabaseName}", "ContosoDatabase");
+var connectionString = connectionStringWithPlaceHolder.Replace("{DatabaseName}", "ContosoDatabase");
 
 builder.Services.AddDbContext<ExampleDbContext>(options =>
     options.UseNpgsql(connectionString
@@ -423,7 +427,7 @@ builder.EnrichNpgsqlDbContext<ExampleDbContext>(
     configureSettings: settings =>
     {
         settings.DisableRetry = false;
-        settings.CommandTimeout = 30 // seconds
+        settings.CommandTimeout = 30; // seconds
     });
 ```
 
@@ -434,7 +438,7 @@ builder.EnrichNpgsqlDbContext<ExampleDbContext>(
 var connectionStringWithPlaceHolder = builder.Configuration.GetConnectionString("database")
     throw new InvalidOperationException("Connection string 'database' not found.");
 
-connectionString = connectionStringWithPlaceHolder.Replace("{DatabaseName}", "ContosoDatabase");
+var connectionString = connectionStringWithPlaceHolder.Replace("{DatabaseName}", "ContosoDatabase");
 
 builder.Services.AddDbContext<ExampleDbContext>(options =>
     options.UseOracle(connectionString
@@ -444,7 +448,7 @@ builder.EnrichOracleDatabaseDbContext<ExampleDbContext>(
     configureSettings: settings =>
     {
         settings.DisableRetry = false;
-        settings.CommandTimeout = 30 // seconds
+        settings.CommandTimeout = 30; // seconds
     });
 ```
 
@@ -455,7 +459,7 @@ builder.EnrichOracleDatabaseDbContext<ExampleDbContext>(
 var connectionStringWithPlaceHolder = builder.Configuration.GetConnectionString("database")
     throw new InvalidOperationException("Connection string 'database' not found.");
 
-connectionString = connectionStringWithPlaceHolder.Replace("{DatabaseName}", "ContosoDatabase");
+var connectionString = connectionStringWithPlaceHolder.Replace("{DatabaseName}", "ContosoDatabase");
 
 builder.Services.AddDbContext<ExampleDbContext>(options =>
     options.UseMySql(connectionString
@@ -465,7 +469,7 @@ builder.EnrichMySqlDbContext<ExampleDbContext>(
     configureSettings: settings =>
     {
         settings.DisableRetry = false;
-        settings.CommandTimeout = 30 // seconds
+        settings.CommandTimeout = 30; // seconds
     });
 ```
 
@@ -492,7 +496,7 @@ builder.EnrichSqlServerDbContext<ExampleDbContext>(
     configureSettings: settings =>
     {
         settings.DisableRetry = false;
-        settings.CommandTimeout = 30 // seconds
+        settings.CommandTimeout = 30; // seconds
     });
 ```
 
@@ -508,7 +512,7 @@ builder.EnrichNpgsqlDbContext<ExampleDbContext>(
     configureSettings: settings =>
     {
         settings.DisableRetry = false;
-        settings.CommandTimeout = 30 // seconds
+        settings.CommandTimeout = 30; // seconds
     });
 ```
 
@@ -524,7 +528,7 @@ builder.EnrichOracleDatabaseDbContext<ExampleDbContext>(
     configureSettings: settings =>
     {
         settings.DisableRetry = false;
-        settings.CommandTimeout = 30 // seconds
+        settings.CommandTimeout = 30; // seconds
     });
 ```
 
@@ -540,7 +544,7 @@ builder.EnrichMySqlDbContext<ExampleDbContext>(
     configureSettings: settings =>
     {
         settings.DisableRetry = false;
-        settings.CommandTimeout = 30 // seconds
+        settings.CommandTimeout = 30; // seconds
     });
 ```
 

--- a/docs/database/entity-framework-core-integration-overview.md
+++ b/docs/database/entity-framework-core-integration-overview.md
@@ -179,7 +179,8 @@ Alternatively, you can add a context to the DI container using the standard EF C
 :::zone pivot="sql-server-ef"
 
 ```csharp
-builder.Services.AddDbContextPool<ExampleDbContext>(options => {
+builder.Services.AddDbContextPool<ExampleDbContext>(options =>
+{
     var connectionString = builder.Configuration.GetConnectionString("database")
         ?? throw new InvalidOperationException("Connection string 'database' not found.");
     options.UseSqlServer(connectionString);
@@ -190,7 +191,8 @@ builder.Services.AddDbContextPool<ExampleDbContext>(options => {
 :::zone pivot="postgresql-ef"
 
 ```csharp
-builder.Services.AddDbContextPool<ExampleDbContext>(options => {
+builder.Services.AddDbContextPool<ExampleDbContext>(options =>
+{
     var connectionString = builder.Configuration.GetConnectionString("database")
         ?? throw new InvalidOperationException("Connection string 'database' not found.");
     options.UseNpgsql(connectionString);
@@ -201,7 +203,8 @@ builder.Services.AddDbContextPool<ExampleDbContext>(options => {
 :::zone pivot="oracle-ef"
 
 ```csharp
-builder.Services.AddDbContextPool<ExampleDbContext>(options => {
+builder.Services.AddDbContextPool<ExampleDbContext>(options =>
+{
     var connectionString = builder.Configuration.GetConnectionString("database")
         ?? throw new InvalidOperationException("Connection string 'database' not found.");
     options.UseOracle(connectionString);
@@ -212,7 +215,8 @@ builder.Services.AddDbContextPool<ExampleDbContext>(options => {
 :::zone pivot="mysql-ef"
 
 ```csharp
-builder.Services.AddDbContextPool<ExampleDbContext>(options => {
+builder.Services.AddDbContextPool<ExampleDbContext>(options =>
+{
     var connectionString = builder.Configuration.GetConnectionString("database")
         ?? throw new InvalidOperationException("Connection string 'database' not found.");
     options.UseMySql(connectionString);


### PR DESCRIPTION
## Summary

After copy-pasting a snippet, I noticed it didn't compile because of missing brackets.
This PR fixes some other smaller issues as well within the code samples.



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/database/entity-framework-core-integration-overview.md](https://github.com/dotnet/docs-aspire/blob/94e50b3d183c0d1f9873a8f310931c8e16f4ab1f/docs/database/entity-framework-core-integration-overview.md) | [Entity Framework Core overview](https://review.learn.microsoft.com/en-us/dotnet/aspire/database/entity-framework-core-integration-overview?branch=pr-en-us-2897) |


<!-- PREVIEW-TABLE-END -->