### PR TITLE
Stagger time when sequester runs

### DIFF
--- a/.github/workflows/quest-bulk.yml
+++ b/.github/workflows/quest-bulk.yml
@@ -1,8 +1,8 @@
 name: "bulk quest import"
 on:
   schedule:
-    - cron: '0 10 * * *' # UTC time, that's 5:00 am EST, 2:00 am PST.
-    - cron: '0 10 6 * *'  # This is the morning of the 6th.
+    - cron: '0 4 1-5,7-31 * *' # UTC time, that's 5:00 am EST, 2:00 am PST.
+    - cron: '0 4 6 * *'  # This is the morning of the 6th.
   workflow_dispatch:
     inputs:
       reason:
@@ -58,4 +58,4 @@ jobs:
           org: ${{ github.repository_owner }}
           repo: ${{ github.repository }}
           issue: '-1'
-          duration: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.duration || github.event.schedule == '0 10 6 * *' && -1 || 5 }}
+          duration: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.duration || github.event.schedule == '0 4 6 * *' && -1 || 5 }}


### PR DESCRIPTION
Stagger the running times of the different repos to match [this table](https://github.com/dotnet/docs-tools/tree/main/actions/sequester#staggering-times)
