### PR TITLE
Update docs to use `EndpointProperty.HostAndPort` where appropriate

### DIFF
--- a/docs/extensibility/custom-hosting-integration.md
+++ b/docs/extensibility/custom-hosting-integration.md
@@ -357,7 +357,7 @@ For example, the `MailDevResource` exposes a property called `ConnectionStringEx
 ```csharp
 public ReferenceExpression ConnectionStringExpression =>
     ReferenceExpression.Create(
-        $"smtp://{SmtpEndpoint.Property(EndpointProperty.Host)}:{SmtpEndpoint.Property(EndpointProperty.Port)}"
+        $"smtp://{SmtpEndpoint.Property(EndpointProperty.HostAndPort)}"
     );
 ```
 

--- a/docs/extensibility/snippets/MailDevResource/MailDev.Hosting/MailDevResource.cs
+++ b/docs/extensibility/snippets/MailDevResource/MailDev.Hosting/MailDevResource.cs
@@ -25,6 +25,6 @@ public sealed class MailDevResource(string name) : ContainerResource(name), IRes
     // the connection string is composed of the SmtpEndpoint endpoint reference.
     public ReferenceExpression ConnectionStringExpression =>
         ReferenceExpression.Create(
-            $"smtp://{SmtpEndpoint.Property(EndpointProperty.Host)}:{SmtpEndpoint.Property(EndpointProperty.Port)}"
+            $"smtp://{SmtpEndpoint.Property(EndpointProperty.HostAndPort)}"
         );
 }

--- a/docs/extensibility/snippets/MailDevResourceAndComponent/MailDev.Hosting/MailDevResource.cs
+++ b/docs/extensibility/snippets/MailDevResourceAndComponent/MailDev.Hosting/MailDevResource.cs
@@ -25,6 +25,6 @@ public sealed class MailDevResource(string name) : ContainerResource(name), IRes
     // the connection string is composed of the SmtpEndpoint endpoint reference.
     public ReferenceExpression ConnectionStringExpression =>
         ReferenceExpression.Create(
-            $"smtp://{SmtpEndpoint.Property(EndpointProperty.Host)}:{SmtpEndpoint.Property(EndpointProperty.Port)}"
+            $"smtp://{SmtpEndpoint.Property(EndpointProperty.HostAndPort)}"
         );
 }

--- a/docs/extensibility/snippets/MailDevResourceWithCredentials/MailDev.Hosting/MailDevResource.cs
+++ b/docs/extensibility/snippets/MailDevResourceWithCredentials/MailDev.Hosting/MailDevResource.cs
@@ -45,6 +45,6 @@ public sealed class MailDevResource(
     // the connection string is composed of the SmtpEndpoint endpoint reference.
     public ReferenceExpression ConnectionStringExpression =>
         ReferenceExpression.Create(
-            $"Endpoint=smtp://{SmtpEndpoint.Property(EndpointProperty.Host)}:{SmtpEndpoint.Property(EndpointProperty.Port)};Username={UserNameReference};Password={PasswordParameter}"
+            $"Endpoint=smtp://{SmtpEndpoint.Property(EndpointProperty.HostAndPort))};Username={UserNameReference};Password={PasswordParameter}"
         );
 }


### PR DESCRIPTION
## Summary

Update docs to use `EndpointProperty.HostAndPort` where appropriate.

Fixes #2646
