### PR TITLE
Rename configs-replace prefix

### DIFF
--- a/docs/app-host/configuration.md
+++ b/docs/app-host/configuration.md
@@ -1,7 +1,7 @@
 ---
 title: .NET Aspire app host configuration
 description: Learn about the .NET Aspire app host configuration options.
-ms.date: 11/21/2024
+ms.date: 04/15/2025
 ms.topic: reference
 ---
 
@@ -29,8 +29,8 @@ App host configuration is provided by the app host launch profile. The app host 
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21030",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22057"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21030",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22057"
       }
     }
   }
@@ -42,7 +42,7 @@ The preceding launch settings file:
 - Has one launch profile named `https`.
 - Configures an .NET Aspire app host project:
   - The `applicationUrl` property configures the dashboard launch address (`ASPNETCORE_URLS`).
-  - Environment variables such as `DOTNET_DASHBOARD_OTLP_ENDPOINT_URL` and `DOTNET_RESOURCE_SERVICE_ENDPOINT_URL` are set on the app host.
+  - Environment variables such as `ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL` and `ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL` are set on the app host.
 
 For more information, see [.NET Aspire and launch profiles](../fundamentals/launch-profiles.md).
 
@@ -53,8 +53,8 @@ For more information, see [.NET Aspire and launch profiles](../fundamentals/laun
 
 | Option | Default value | Description |
 |--|--|--|
-| `ASPIRE_ALLOW_UNSECURED_TRANSPORT` | `false` | Allows communication with the app host without https. `ASPNETCORE_URLS` (dashboard address) and `DOTNET_RESOURCE_SERVICE_ENDPOINT_URL` (app host resource service address) must be secured with HTTPS unless true. |
-| `DOTNET_ASPIRE_CONTAINER_RUNTIME` | `docker` | Allows the user of alternative container runtimes for resources backed by containers. Possible values are `docker` (default) or `podman`. See [Setup and tooling overview for more details](../fundamentals/setup-tooling.md).  |
+| `ASPIRE_ALLOW_UNSECURED_TRANSPORT` | `false` | Allows communication with the app host without https. `ASPNETCORE_URLS` (dashboard address) and `ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL` (app host resource service address) must be secured with HTTPS unless true. |
+| `ASPIRE_CONTAINER_RUNTIME` | `docker` | Allows the user of alternative container runtimes for resources backed by containers. Possible values are `docker` (default) or `podman`. See [Setup and tooling overview for more details](../fundamentals/setup-tooling.md).  |
 
 ## Resource service
 
@@ -62,8 +62,8 @@ A resource service is hosted by the app host. The resource service is used by th
 
 | Option | Default value | Description |
 |--|--|--|
-| `DOTNET_RESOURCE_SERVICE_ENDPOINT_URL` | `null` | Configures the address of the resource service hosted by the app host. Automatically generated with _launchSettings.json_ to have a random port on localhost. For example, `https://localhost:17037`. |
-| `DOTNET_DASHBOARD_RESOURCESERVICE_APIKEY` | Automatically generated 128-bit entropy token. | The API key used to authenticate requests made to the app host's resource service. The API key is required if the app host is in run mode, the dashboard isn't disabled, and the dashboard isn't configured to allow anonymous access with `DOTNET_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS`. |
+| `ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL` | `null` | Configures the address of the resource service hosted by the app host. Automatically generated with _launchSettings.json_ to have a random port on localhost. For example, `https://localhost:17037`. |
+| `ASPIRE_DASHBOARD_RESOURCESERVICE_APIKEY` | Automatically generated 128-bit entropy token. | The API key used to authenticate requests made to the app host's resource service. The API key is required if the app host is in run mode, the dashboard isn't disabled, and the dashboard isn't configured to allow anonymous access with `ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS`. |
 
 ## Dashboard
 
@@ -73,10 +73,10 @@ By default, the dashboard is automatically started by the app host. The dashboar
 |--|--|--|
 | `ASPNETCORE_URLS` | `null` | Dashboard address. Must be `https` unless `ASPIRE_ALLOW_UNSECURED_TRANSPORT` or `DistributedApplicationOptions.AllowUnsecuredTransport` is true. Automatically generated with _launchSettings.json_ to have a random port on localhost. The value in launch settings is set on the `applicationUrls` property. |
 | `ASPNETCORE_ENVIRONMENT` | `Production` | Configures the environment the dashboard runs as. For more information, see [Use multiple environments in ASP.NET Core](/aspnet/core/fundamentals/environments). |
-| `DOTNET_DASHBOARD_OTLP_ENDPOINT_URL` | `http://localhost:18889` if no gRPC endpoint is configured. | Configures the dashboard OTLP gRPC address. Used by the dashboard to receive telemetry over OTLP. Set on resources as the `OTEL_EXPORTER_OTLP_ENDPOINT` env var. The `OTEL_EXPORTER_OTLP_PROTOCOL` env var is `grpc`.  Automatically generated with _launchSettings.json_ to have a random port on localhost. |
-| `DOTNET_DASHBOARD_OTLP_HTTP_ENDPOINT_URL` | `null` | Configures the dashboard OTLP HTTP address. Used by the dashboard to receive telemetry over OTLP. If only `DOTNET_DASHBOARD_OTLP_HTTP_ENDPOINT_URL` is configured then it is set on resources as the `OTEL_EXPORTER_OTLP_ENDPOINT` env var. The `OTEL_EXPORTER_OTLP_PROTOCOL` env var is `http/protobuf`. |
-| `DOTNET_DASHBOARD_CORS_ALLOWED_ORIGINS` | `null` | Overrides the CORS allowed origins configured in the dashboard. This setting replaces the default behavior of calculating allowed origins based on resource endpoints. |
-| `DOTNET_DASHBOARD_FRONTEND_BROWSERTOKEN` | Automatically generated 128-bit entropy token. | Configures the frontend browser token. This is the value that must be entered to access the dashboard when the auth mode is BrowserToken. If no browser token is specified then a new token is generated each time the app host is launched. |
+| `ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL` | `http://localhost:18889` if no gRPC endpoint is configured. | Configures the dashboard OTLP gRPC address. Used by the dashboard to receive telemetry over OTLP. Set on resources as the `OTEL_EXPORTER_OTLP_ENDPOINT` env var. The `OTEL_EXPORTER_OTLP_PROTOCOL` env var is `grpc`.  Automatically generated with _launchSettings.json_ to have a random port on localhost. |
+| `ASPIRE_DASHBOARD_OTLP_HTTP_ENDPOINT_URL` | `null` | Configures the dashboard OTLP HTTP address. Used by the dashboard to receive telemetry over OTLP. If only `ASPIRE_DASHBOARD_OTLP_HTTP_ENDPOINT_URL` is configured then it is set on resources as the `OTEL_EXPORTER_OTLP_ENDPOINT` env var. The `OTEL_EXPORTER_OTLP_PROTOCOL` env var is `http/protobuf`. |
+| `ASPIRE_DASHBOARD_CORS_ALLOWED_ORIGINS` | `null` | Overrides the CORS allowed origins configured in the dashboard. This setting replaces the default behavior of calculating allowed origins based on resource endpoints. |
+| `ASPIRE_DASHBOARD_FRONTEND_BROWSERTOKEN` | Automatically generated 128-bit entropy token. | Configures the frontend browser token. This is the value that must be entered to access the dashboard when the auth mode is BrowserToken. If no browser token is specified then a new token is generated each time the app host is launched. |
 
 ## Internal
 
@@ -87,7 +87,7 @@ Internal settings are used by the app host and integrations. Internal settings a
 | `AppHost:Directory` | The content root if there's no project. | Directory of the project where the app host is located. Accessible from the <xref:Aspire.Hosting.IDistributedApplicationBuilder.AppHostDirectory?displayProperty=nameWithType>. |
 | `AppHost:Path` | The directory combined with the application name. | The path to the app host. It combines the directory with the application name. |
 | `AppHost:Sha256` | It is created from the app host name when the app host is in publish mode. Otherwise it is created from the app host path. | Hex encoded hash for the current application. The hash is based on the location of the app on the current machine so it is stable between launches of the app host. |
-| `AppHost:OtlpApiKey` | Automatically generated 128-bit entropy token. | The API key used to authenticate requests sent to the dashboard OTLP service. The value is present if needed: the app host is in run mode, the dashboard isn't disabled, and the dashboard isn't configured to allow anonymous access with `DOTNET_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS`. |
-| `AppHost:BrowserToken` | Automatically generated 128-bit entropy token. | The browser token used to authenticate browsing to the dashboard when it is launched by the app host. The browser token can be set by `DOTNET_DASHBOARD_FRONTEND_BROWSERTOKEN`. The value is present if needed: the app host is in run mode, the dashboard isn't disabled, and the dashboard isn't configured to allow anonymous access with `DOTNET_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS`. |
-| `AppHost:ResourceService:AuthMode` | `ApiKey`. If `DOTNET_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS` is true then the value is `Unsecured`. | The authentication mode used to access the resource service. The value is present if needed: the app host is in run mode and the dashboard isn't disabled. |
-| `AppHost:ResourceService:ApiKey` | Automatically generated 128-bit entropy token. | The API key used to authenticate requests made to the app host's resource service. The API key can be set by `DOTNET_DASHBOARD_RESOURCESERVICE_APIKEY`. The value is present if needed: the app host is in run mode, the dashboard isn't disabled, and the dashboard isn't configured to allow anonymous access with `DOTNET_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS`. |
+| `AppHost:OtlpApiKey` | Automatically generated 128-bit entropy token. | The API key used to authenticate requests sent to the dashboard OTLP service. The value is present if needed: the app host is in run mode, the dashboard isn't disabled, and the dashboard isn't configured to allow anonymous access with `ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS`. |
+| `AppHost:BrowserToken` | Automatically generated 128-bit entropy token. | The browser token used to authenticate browsing to the dashboard when it is launched by the app host. The browser token can be set by `ASPIRE_DASHBOARD_FRONTEND_BROWSERTOKEN`. The value is present if needed: the app host is in run mode, the dashboard isn't disabled, and the dashboard isn't configured to allow anonymous access with `ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS`. |
+| `AppHost:ResourceService:AuthMode` | `ApiKey`. If `ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS` is true then the value is `Unsecured`. | The authentication mode used to access the resource service. The value is present if needed: the app host is in run mode and the dashboard isn't disabled. |
+| `AppHost:ResourceService:ApiKey` | Automatically generated 128-bit entropy token. | The API key used to authenticate requests made to the app host's resource service. The API key can be set by `ASPIRE_DASHBOARD_RESOURCESERVICE_APIKEY`. The value is present if needed: the app host is in run mode, the dashboard isn't disabled, and the dashboard isn't configured to allow anonymous access with `ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS`. |

--- a/docs/app-host/snippets/AspireApp/AspireApp.AppHost/Properties/launchSettings.json
+++ b/docs/app-host/snippets/AspireApp/AspireApp.AppHost/Properties/launchSettings.json
@@ -9,8 +9,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21137",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22259"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21137",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22259"
       }
     },
     "http": {
@@ -21,8 +21,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19091",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20229"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19091",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20229"
       }
     }
   }

--- a/docs/app-host/snippets/AspireApp/AspireApp.ResourceAppHost/Properties/launchSettings.json
+++ b/docs/app-host/snippets/AspireApp/AspireApp.ResourceAppHost/Properties/launchSettings.json
@@ -9,8 +9,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21272",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22185"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21272",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22185"
       }
     },
     "http": {
@@ -21,8 +21,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19149",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20298"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19149",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20298"
       }
     }
   }

--- a/docs/authentication/snippets/AspireApp/AspireApp.AppHost/Properties/launchSettings.json
+++ b/docs/authentication/snippets/AspireApp/AspireApp.AppHost/Properties/launchSettings.json
@@ -9,8 +9,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21257",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22149"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21257",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22149"
       }
     },
     "http": {
@@ -21,8 +21,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19200",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20201"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19200",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20201"
       }
     }
   }

--- a/docs/azure/snippets/aca/AspireAca.AppHost/AspireApp.AppHost/Properties/launchSettings.json
+++ b/docs/azure/snippets/aca/AspireAca.AppHost/AspireApp.AppHost/Properties/launchSettings.json
@@ -9,8 +9,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21283",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22129"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21283",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22129"
       }
     },
     "http": {
@@ -21,8 +21,8 @@
         "environmentVariables": {
             "ASPNETCORE_ENVIRONMENT": "Development",
             "DOTNET_ENVIRONMENT": "Development",
-            "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19097",
-            "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20224"
+            "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19097",
+            "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20224"
         }
     },
     "generate-manifest": {

--- a/docs/azure/snippets/bicep/AppHost.Bicep/Properties/launchSettings.json
+++ b/docs/azure/snippets/bicep/AppHost.Bicep/Properties/launchSettings.json
@@ -9,8 +9,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21208",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22139"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21208",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22139"
       }
     },
     "http": {
@@ -21,8 +21,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19077",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20027"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19077",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20027"
       }
     }
   }

--- a/docs/database/snippets/cosmos-db/AspireApp.AppHost/Properties/launchSettings.json
+++ b/docs/database/snippets/cosmos-db/AspireApp.AppHost/Properties/launchSettings.json
@@ -9,8 +9,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21184",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22278"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21184",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22278"
       }
     },
     "http": {
@@ -21,8 +21,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19142",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20090"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19142",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20090"
       }
     }
   }

--- a/docs/database/snippets/tutorial/aspiresqldeployazure/AspireSql.AppHost/Properties/launchSettings.json
+++ b/docs/database/snippets/tutorial/aspiresqldeployazure/AspireSql.AppHost/Properties/launchSettings.json
@@ -9,8 +9,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21277",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22047"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21277",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22047"
       }
     },
     "http": {
@@ -21,8 +21,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19271",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20006"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19271",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20006"
       }
     }
   }

--- a/docs/database/snippets/tutorial/aspiresqldeploycontainer/AspireSql.AppHost/Properties/launchSettings.json
+++ b/docs/database/snippets/tutorial/aspiresqldeploycontainer/AspireSql.AppHost/Properties/launchSettings.json
@@ -9,8 +9,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21277",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22047"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21277",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22047"
       }
     },
     "http": {
@@ -21,8 +21,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19271",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20006"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19271",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20006"
       }
     }
   }

--- a/docs/database/snippets/tutorial/aspiresqlefcore/AspireSQLEFCore.AppHost/Properties/launchSettings.json
+++ b/docs/database/snippets/tutorial/aspiresqlefcore/AspireSQLEFCore.AppHost/Properties/launchSettings.json
@@ -9,8 +9,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21115",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22115"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21115",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22115"
       }
     },
     "http": {
@@ -21,9 +21,9 @@
       "environmentVariables": {
         "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true",
         "ASPNETCORE_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16053",
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16053",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:22259"
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:22259"
       }
     }
   }

--- a/docs/extensibility/snippets/MailDevResource/MailDevResource.AppHost/Properties/launchSettings.json
+++ b/docs/extensibility/snippets/MailDevResource/MailDevResource.AppHost/Properties/launchSettings.json
@@ -9,8 +9,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21161",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22175"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21161",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22175"
       }
     },
     "http": {
@@ -21,8 +21,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19277",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20014"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19277",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20014"
       }
     }
   }

--- a/docs/extensibility/snippets/MailDevResourceAndComponent/MailDevResource.AppHost/Properties/launchSettings.json
+++ b/docs/extensibility/snippets/MailDevResourceAndComponent/MailDevResource.AppHost/Properties/launchSettings.json
@@ -9,8 +9,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21161",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22175"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21161",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22175"
       }
     },
     "http": {
@@ -21,8 +21,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19277",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20014"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19277",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20014"
       }
     }
   }

--- a/docs/extensibility/snippets/MailDevResourceWithCredentials/MailDevResource.AppHost/Properties/launchSettings.json
+++ b/docs/extensibility/snippets/MailDevResourceWithCredentials/MailDevResource.AppHost/Properties/launchSettings.json
@@ -9,8 +9,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21161",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22175"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21161",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22175"
       }
     },
     "http": {
@@ -21,8 +21,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19277",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20014"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19277",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20014"
       }
     }
   }

--- a/docs/frameworks/snippets/Dapr/Dapr.AppHost/Properties/launchSettings.json
+++ b/docs/frameworks/snippets/Dapr/Dapr.AppHost/Properties/launchSettings.json
@@ -9,8 +9,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21181",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22225"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21181",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22225"
       }
     },
     "http": {
@@ -21,8 +21,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19169",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20292"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19169",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20292"
       }
     }
   }

--- a/docs/frameworks/snippets/Orleans/OrleansAppHost/Properties/launchSettings.json
+++ b/docs/frameworks/snippets/Orleans/OrleansAppHost/Properties/launchSettings.json
@@ -8,9 +8,9 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:16031",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:17037",
-        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:16031",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:17037",
+        "ASPIRE_SHOW_DASHBOARD_RESOURCES": "true"
       }
     },
     "http": {
@@ -21,9 +21,9 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16031",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:17038",
-        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true",
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16031",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:17038",
+        "ASPIRE_SHOW_DASHBOARD_RESOURCES": "true",
         "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
       }
     },
@@ -36,7 +36,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16031"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16031"
       }
     }
   },

--- a/docs/fundamentals/dashboard/automation/aspire-dashboard/AspireSample/AspireSample.AppHost/Properties/launchSettings.json
+++ b/docs/fundamentals/dashboard/automation/aspire-dashboard/AspireSample/AspireSample.AppHost/Properties/launchSettings.json
@@ -9,8 +9,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21053",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22079"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21053",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22079"
       }
     },
     "http": {
@@ -21,8 +21,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19276",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20169"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19276",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20169"
       }
     }
   }

--- a/docs/fundamentals/dashboard/configuration.md
+++ b/docs/fundamentals/dashboard/configuration.md
@@ -1,7 +1,7 @@
 ---
 title: .NET Aspire dashboard configuration
 description: .NET Aspire dashboard configuration options
-ms.date: 03/20/2025
+ms.date: 04/15/2025
 ms.topic: reference
 ---
 
@@ -15,7 +15,7 @@ There are many ways to provide configuration:
 
 - Command line arguments.
 - Environment variables. The `:` delimiter should be replaced with double underscore (`__`) in environment variable names.
-- Optional JSON configuration file. The `DOTNET_DASHBOARD_CONFIG_FILE_PATH` setting can be used to specify a JSON configuration file.
+- Optional JSON configuration file. The `ASPIRE_DASHBOARD_CONFIG_FILE_PATH` setting can be used to specify a JSON configuration file.
 
 Consider the following example, which shows how to configure the dashboard when started from a Docker container:
 
@@ -41,7 +41,7 @@ docker run --rm -it -p 18888:18888 -p 4317:18889 -d --name aspire-dashboard `
 
 ---
 
-Alternatively, these same values could be configured using a JSON configuration file that is specified using `DOTNET_DASHBOARD_CONFIG_FILE_PATH`:
+Alternatively, these same values could be configured using a JSON configuration file that is specified using `ASPIRE_DASHBOARD_CONFIG_FILE_PATH`:
 
 ```json
 {
@@ -70,12 +70,12 @@ Alternatively, these same values could be configured using a JSON configuration 
 | Option | Default value | Description |
 |--|--|--|
 | `ASPNETCORE_URLS` | `http://localhost:18888` | One or more HTTP endpoints through which the dashboard frontend is served. The frontend endpoint is used to view the dashboard in a browser. When the dashboard is launched by the .NET Aspire app host this address is secured with HTTPS. Securing the dashboard with HTTPS is recommended. |
-| `DOTNET_DASHBOARD_OTLP_ENDPOINT_URL` | `http://localhost:18889` | The [OTLP/gRPC](https://opentelemetry.io/docs/specs/otlp/#otlpgrpc) endpoint. This endpoint hosts an OTLP service and receives telemetry using gRPC. When the dashboard is launched by the .NET Aspire app host this address is secured with HTTPS. Securing the dashboard with HTTPS is recommended. |
-| `DOTNET_DASHBOARD_OTLP_HTTP_ENDPOINT_URL` | `http://localhost:18890` | The [OTLP/HTTP](https://opentelemetry.io/docs/specs/otlp/#otlphttp) endpoint. This endpoint hosts an OTLP service and receives telemetry using Protobuf over HTTP. When the dashboard is launched by the .NET Aspire app host the OTLP/HTTP endpoint isn't configured by default. To configure an OTLP/HTTP endpoint with the app host, set an `DOTNET_DASHBOARD_OTLP_HTTP_ENDPOINT_URL` env var value in _launchSettings.json_. Securing the dashboard with HTTPS is recommended. |
-| `DOTNET_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS` | `false` | Configures the dashboard to not use authentication and accepts anonymous access. This setting is a shortcut to configuring `Dashboard:Frontend:AuthMode` and `Dashboard:Otlp:AuthMode` to `Unsecured`. |
-| `DOTNET_DASHBOARD_CONFIG_FILE_PATH` | `null` | The path for a JSON configuration file. If the dashboard is being run in a Docker container, then this is the path to the configuration file in a mounted volume. This value is optional. |
-| `DOTNET_DASHBOARD_FILE_CONFIG_DIRECTORY` | `null` | The directory where the dashboard looks for key-per-file configuration. This value is optional. |
-| `DOTNET_RESOURCE_SERVICE_ENDPOINT_URL` | `null` | The gRPC endpoint to which the dashboard connects for its data. If this value is unspecified, the dashboard shows telemetry data but no resource list or console logs. This setting is a shortcut to `Dashboard:ResourceServiceClient:Url`. |
+| `ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL` | `http://localhost:18889` | The [OTLP/gRPC](https://opentelemetry.io/docs/specs/otlp/#otlpgrpc) endpoint. This endpoint hosts an OTLP service and receives telemetry using gRPC. When the dashboard is launched by the .NET Aspire app host this address is secured with HTTPS. Securing the dashboard with HTTPS is recommended. |
+| `ASPIRE_DASHBOARD_OTLP_HTTP_ENDPOINT_URL` | `http://localhost:18890` | The [OTLP/HTTP](https://opentelemetry.io/docs/specs/otlp/#otlphttp) endpoint. This endpoint hosts an OTLP service and receives telemetry using Protobuf over HTTP. When the dashboard is launched by the .NET Aspire app host the OTLP/HTTP endpoint isn't configured by default. To configure an OTLP/HTTP endpoint with the app host, set an `ASPIRE_DASHBOARD_OTLP_HTTP_ENDPOINT_URL` env var value in _launchSettings.json_. Securing the dashboard with HTTPS is recommended. |
+| `ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS` | `false` | Configures the dashboard to not use authentication and accepts anonymous access. This setting is a shortcut to configuring `Dashboard:Frontend:AuthMode` and `Dashboard:Otlp:AuthMode` to `Unsecured`. |
+| `ASPIRE_DASHBOARD_CONFIG_FILE_PATH` | `null` | The path for a JSON configuration file. If the dashboard is being run in a Docker container, then this is the path to the configuration file in a mounted volume. This value is optional. |
+| `ASPIRE_DASHBOARD_FILE_CONFIG_DIRECTORY` | `null` | The directory where the dashboard looks for key-per-file configuration. This value is optional. |
+| `ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL` | `null` | The gRPC endpoint to which the dashboard connects for its data. If this value is unspecified, the dashboard shows telemetry data but no resource list or console logs. This setting is a shortcut to `Dashboard:ResourceServiceClient:Url`. |
 
 ## Frontend authentication
 

--- a/docs/fundamentals/dashboard/enable-browser-telemetry.md
+++ b/docs/fundamentals/dashboard/enable-browser-telemetry.md
@@ -1,7 +1,7 @@
 ---
 title: Enable browser telemetry
 description: Learn how to enable browser telemetry in the .NET Aspire dashboard.
-ms.date: 11/11/2024
+ms.date: 04/15/2025
 ---
 
 # Enable browser telemetry
@@ -23,8 +23,8 @@ The .NET Aspire dashboard receives telemetry through OTLP endpoints. [HTTP OTLP 
 
 To configure the gPRC or HTTP endpoints, specify the following environment variables:
 
-- `DOTNET_DASHBOARD_OTLP_ENDPOINT_URL`: The gRPC endpoint to which the dashboard connects for its data.
-- `DOTNET_DASHBOARD_OTLP_HTTP_ENDPOINT_URL`: The HTTP endpoint to which the dashboard connects for its data.
+- `ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL`: The gRPC endpoint to which the dashboard connects for its data.
+- `ASPIRE_DASHBOARD_OTLP_HTTP_ENDPOINT_URL`: The HTTP endpoint to which the dashboard connects for its data.
 
 Configuration of the HTTP OTLP endpoint depends on whether the dashboard is started by the app host or is run standalone.
 
@@ -36,7 +36,7 @@ Consider the following example JSON file:
 
 :::code language="json" source="snippets/BrowserTelemetry/BrowserTelemetry.AppHost/Properties/launchSettings.json" highlight="12,25":::
 
-The preceding launch settings JSON file configures all profiles to include the `DOTNET_DASHBOARD_OTLP_HTTP_ENDPOINT_URL` environment variable.
+The preceding launch settings JSON file configures all profiles to include the `ASPIRE_DASHBOARD_OTLP_HTTP_ENDPOINT_URL` environment variable.
 
 #### Configure OTLP HTTP with standalone dashboard
 
@@ -112,7 +112,7 @@ For more information, see [.NET Aspire dashboard configuration: OTLP CORS](confi
 
 Dashboard OTLP endpoints can be secured with API key authentication. When enabled, HTTP OTLP requests to the dashboard must include the API key as the `x-otlp-api-key` header. By default a new  API key is generated each time the dashboard is run.
 
-API key authentication is automatically enabled when the dashboard is run from the app host. Dashboard authentication can be disabled by setting `DOTNET_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS` to `true` in the app host's _launchSettings.json_ file.
+API key authentication is automatically enabled when the dashboard is run from the app host. Dashboard authentication can be disabled by setting `ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS` to `true` in the app host's _launchSettings.json_ file.
 
 OTLP endpoints are unsecured by default in the standalone dashboard.
 

--- a/docs/fundamentals/dashboard/security-considerations.md
+++ b/docs/fundamentals/dashboard/security-considerations.md
@@ -1,7 +1,7 @@
 ---
 title: .NET Aspire dashboard security considerations
 description: Security considerations for running the .NET Aspire dashboard
-ms.date: 11/20/2024
+ms.date: 04/15/2025
 ms.topic: reference
 ---
 
@@ -19,7 +19,7 @@ The dashboard can be run in different scenarios, such as being automatically sta
 
 The dashboard is automatically started when an .NET Aspire app host is run. The dashboard is secure by default when run from .NET Aspire tooling:
 
-- Transport is secured with HTTPS. Using HTTPS is configured by default in _launchSettings.json_. The launch profile includes `https` addresses in `applicationUrl` and `DOTNET_DASHBOARD_OTLP_ENDPOINT_URL` values.
+- Transport is secured with HTTPS. Using HTTPS is configured by default in _launchSettings.json_. The launch profile includes `https` addresses in `applicationUrl` and `ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL` values.
 - Browser frontend authenticated with a browser token.
 - Incoming telemetry authenticated with an API key.
 

--- a/docs/fundamentals/dashboard/snippets/BrowserTelemetry/BrowserTelemetry.AppHost/Properties/launchSettings.json
+++ b/docs/fundamentals/dashboard/snippets/BrowserTelemetry/BrowserTelemetry.AppHost/Properties/launchSettings.json
@@ -9,9 +9,9 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_HTTP_ENDPOINT_URL": "https://localhost:16175",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:17037",
-        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true"
+        "ASPIRE_DASHBOARD_OTLP_HTTP_ENDPOINT_URL": "https://localhost:16175",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:17037",
+        "ASPIRE_SHOW_DASHBOARD_RESOURCES": "true"
       }
     },
     "http": {
@@ -22,9 +22,9 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_HTTP_ENDPOINT_URL": "http://localhost:16175",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:17037",
-        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true",
+        "ASPIRE_DASHBOARD_OTLP_HTTP_ENDPOINT_URL": "http://localhost:16175",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:17037",
+        "ASPIRE_SHOW_DASHBOARD_RESOURCES": "true",
         "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
       }
     },

--- a/docs/fundamentals/dashboard/standalone.md
+++ b/docs/fundamentals/dashboard/standalone.md
@@ -1,7 +1,7 @@
 ---
 title: Standalone .NET Aspire dashboard
 description: How to use the .NET Aspire dashboard standalone.
-ms.date: 10/29/2024
+ms.date: 04/15/2025
 ms.topic: reference
 ---
 
@@ -56,7 +56,7 @@ When the dashboard is run from a standalone container, the login token is printe
 :::image type="content" source="media/standalone/aspire-dashboard-container-log.png" lightbox="media/standalone/aspire-dashboard-container-log.png" alt-text="Screenshot of the .NET Aspire dashboard container logs.":::
 
 > [!TIP]
-> To avoid the login, you can disable the authentication requirement by setting the `DOTNET_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS` environment variable to `true`. Additional configuration is available, see [Dashboard configuration](configuration.md).
+> To avoid the login, you can disable the authentication requirement by setting the `ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS` environment variable to `true`. Additional configuration is available, see [Dashboard configuration](configuration.md).
 
 For more information about logging into the dashboard, see [Dashboard authentication](explore.md#dashboard-authentication).
 

--- a/docs/fundamentals/launch-profiles.md
+++ b/docs/fundamentals/launch-profiles.md
@@ -1,7 +1,7 @@
 ---
 title: .NET Aspire and launch profiles
 description: Learn how .NET Aspire integrates with .NET launch profiles.
-ms.date: 04/23/2024
+ms.date: 04/15/2025
 ---
 
 # .NET Aspire and launch profiles
@@ -70,8 +70,8 @@ In .NET Aspire, the AppHost is just a .NET application. As a result it has a `la
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21030",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22057"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21030",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22057"
       }
     },
     "http": {
@@ -82,8 +82,8 @@ In .NET Aspire, the AppHost is just a .NET application. As a result it has a `la
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19240",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20154"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19240",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20154"
       }
     }
   }

--- a/docs/fundamentals/setup-tooling.md
+++ b/docs/fundamentals/setup-tooling.md
@@ -1,7 +1,7 @@
 ---
 title: .NET Aspire tooling
 description: Learn about essential tooling concepts for .NET Aspire.
-ms.date: 03/11/2025
+ms.date: 04/15/2025
 zone_pivot_groups: dev-environment
 uid: dotnet/aspire/setup-tooling
 ---
@@ -136,12 +136,12 @@ For more information, see [.NET Aspire templates](aspire-sdk-templates.md).
 
 ## Container runtime
 
-.NET Aspire projects are designed to run in containers. You can use either Docker Desktop or Podman as your container runtime. [Docker Desktop](https://www.docker.com/products/docker-desktop/) is the most common container runtime. [Podman](https://podman.io/docs/installation) is an open-source daemonless alternative to Docker, that can build and run Open Container Initiative (OCI) containers. If your host environment has both Docker and Podman installed, .NET Aspire defaults to using Docker. You can instruct .NET Aspire to use Podman instead, by setting the `DOTNET_ASPIRE_CONTAINER_RUNTIME` environment variable to `podman`:
+.NET Aspire projects are designed to run in containers. You can use either Docker Desktop or Podman as your container runtime. [Docker Desktop](https://www.docker.com/products/docker-desktop/) is the most common container runtime. [Podman](https://podman.io/docs/installation) is an open-source daemonless alternative to Docker, that can build and run Open Container Initiative (OCI) containers. If your host environment has both Docker and Podman installed, .NET Aspire defaults to using Docker. You can instruct .NET Aspire to use Podman instead, by setting the `ASPIRE_CONTAINER_RUNTIME` environment variable to `podman`:
 
 ## [Linux](#tab/linux)
 
 ```bash
-export DOTNET_ASPIRE_CONTAINER_RUNTIME=podman
+export ASPIRE_CONTAINER_RUNTIME=podman
 ```
 
 For more information, see [Install Podman on Linux](https://podman.io/docs/installation#installing-on-linux).
@@ -149,7 +149,7 @@ For more information, see [Install Podman on Linux](https://podman.io/docs/insta
 ## [Windows](#tab/windows)
 
 ```powershell
-[System.Environment]::SetEnvironmentVariable("DOTNET_ASPIRE_CONTAINER_RUNTIME", "podman", "User")
+[System.Environment]::SetEnvironmentVariable("ASPIRE_CONTAINER_RUNTIME", "podman", "User")
 ```
 
 For more information, see [Install Podman on Windows](https://podman.io/docs/installation#installing-on-mac--windows).

--- a/docs/fundamentals/snippets/custom-commands/AspireApp/AspireApp.AppHost/Properties/launchSettings.json
+++ b/docs/fundamentals/snippets/custom-commands/AspireApp/AspireApp.AppHost/Properties/launchSettings.json
@@ -9,8 +9,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21124",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22206"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21124",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22206"
       }
     },
     "http": {
@@ -21,8 +21,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19112",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20019"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19112",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20019"
       }
     }
   }

--- a/docs/fundamentals/snippets/custom-urls/AspireApp.AppHost/Properties/launchSettings.json
+++ b/docs/fundamentals/snippets/custom-urls/AspireApp.AppHost/Properties/launchSettings.json
@@ -9,8 +9,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21040",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22015"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21040",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22015"
       }
     },
     "http": {
@@ -21,8 +21,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19142",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20239"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19142",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20239"
       }
     }
   }

--- a/docs/fundamentals/snippets/http-commands/AspireApp/AspireApp.AppHost/Properties/launchSettings.json
+++ b/docs/fundamentals/snippets/http-commands/AspireApp/AspireApp.AppHost/Properties/launchSettings.json
@@ -9,8 +9,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21270",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22132"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21270",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22132"
       }
     },
     "http": {
@@ -21,8 +21,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19122",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20186"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19122",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20186"
       }
     }
   }

--- a/docs/fundamentals/snippets/integrations/AspireApp/AspireApp.AppHost/Properties/launchSettings.json
+++ b/docs/fundamentals/snippets/integrations/AspireApp/AspireApp.AppHost/Properties/launchSettings.json
@@ -9,8 +9,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21006",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22231"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21006",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22231"
       }
     },
     "http": {
@@ -21,8 +21,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16244",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:22153"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16244",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:22153"
       }
     }
   }

--- a/docs/fundamentals/snippets/lifecycles/AspireApp/AspireApp.AppHost/Properties/launchSettings.json
+++ b/docs/fundamentals/snippets/lifecycles/AspireApp/AspireApp.AppHost/Properties/launchSettings.json
@@ -9,8 +9,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21196",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22093"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21196",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22093"
       }
     },
     "http": {
@@ -21,8 +21,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19108",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20219"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19108",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20219"
       }
     }
   }

--- a/docs/fundamentals/snippets/networking/Networking.AppHost/Properties/launchSettings.json
+++ b/docs/fundamentals/snippets/networking/Networking.AppHost/Properties/launchSettings.json
@@ -9,8 +9,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21199",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22199"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21199",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22199"
       }
     },
     "http": {
@@ -21,9 +21,9 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16244",
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16244",
         "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:22157"
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:22157"
       }
     }
   }

--- a/docs/fundamentals/snippets/params/Parameters.AppHost/Properties/launchSettings.json
+++ b/docs/fundamentals/snippets/params/Parameters.AppHost/Properties/launchSettings.json
@@ -9,8 +9,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21259",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22259"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21259",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22259"
       }
     },
     "http": {
@@ -21,8 +21,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16204",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:22064"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16204",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:22064"
       }
     }
   }

--- a/docs/fundamentals/snippets/volumes/VolumeMounts.AppHost/Properties/launchSettings.json
+++ b/docs/fundamentals/snippets/volumes/VolumeMounts.AppHost/Properties/launchSettings.json
@@ -7,8 +7,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21089",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22059"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21089",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22059"
       },
       "dotnetRunMessages": true,
       "applicationUrl": "https://localhost:17297;http://localhost:15085"
@@ -20,8 +20,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19072",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20277"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19072",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20277"
       },
       "dotnetRunMessages": true,
       "applicationUrl": "http://localhost:15085"

--- a/docs/get-started/snippets/PythonSample/PythonSample.AppHost/Properties/launchSettings.json
+++ b/docs/get-started/snippets/PythonSample/PythonSample.AppHost/Properties/launchSettings.json
@@ -9,8 +9,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21171",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22122"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21171",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22122"
       }
     },
     "http": {
@@ -21,8 +21,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19171",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20208",
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19171",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20208",
         "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
       }
     }

--- a/docs/get-started/snippets/quickstart/AspireSample/AspireSample.AppHost/Properties/launchSettings.json
+++ b/docs/get-started/snippets/quickstart/AspireSample/AspireSample.AppHost/Properties/launchSettings.json
@@ -9,8 +9,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21086",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22296"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21086",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22296"
       }
     },
     "http": {
@@ -21,8 +21,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19141",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20153"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19141",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20153"
       }
     }
   }

--- a/docs/real-time/snippets/signalr/SignalR.AppHost/Properties/launchSettings.json
+++ b/docs/real-time/snippets/signalr/SignalR.AppHost/Properties/launchSettings.json
@@ -9,8 +9,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:16046",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22128"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:16046",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22128"
       }
     }
   }

--- a/docs/snippets/azure/AppHost/Properties/launchSettings.json
+++ b/docs/snippets/azure/AppHost/Properties/launchSettings.json
@@ -9,8 +9,8 @@
             "environmentVariables": {
                 "ASPNETCORE_ENVIRONMENT": "Development",
                 "DOTNET_ENVIRONMENT": "Development",
-                "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21128",
-                "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22251"
+                "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21128",
+                "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22251"
             }
         },
         "http": {
@@ -21,8 +21,8 @@
             "environmentVariables": {
                 "ASPNETCORE_ENVIRONMENT": "Development",
                 "DOTNET_ENVIRONMENT": "Development",
-                "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19195",
-                "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20163"
+                "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19195",
+                "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20163"
             }
         },
         "generate-manifest": {

--- a/docs/storage/snippets/tutorial/AspireStorage/AspireStorage.AppHost/Properties/launchSettings.json
+++ b/docs/storage/snippets/tutorial/AspireStorage/AspireStorage.AppHost/Properties/launchSettings.json
@@ -9,8 +9,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21170",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22000"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21170",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22000"
       }
     },
     "http": {
@@ -21,8 +21,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19116",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20100"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19116",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20100"
       }
     }
   }

--- a/docs/testing/snippets/testing/mstest/AspireApp.AppHost/Properties/launchSettings.json
+++ b/docs/testing/snippets/testing/mstest/AspireApp.AppHost/Properties/launchSettings.json
@@ -9,8 +9,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21193",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22213"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21193",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22213"
       }
     },
     "http": {
@@ -21,8 +21,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19275",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20199"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19275",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20199"
       }
     }
   }

--- a/docs/testing/snippets/testing/nunit/AspireApp.AppHost/Properties/launchSettings.json
+++ b/docs/testing/snippets/testing/nunit/AspireApp.AppHost/Properties/launchSettings.json
@@ -9,8 +9,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21173",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22005"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21173",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22005"
       }
     },
     "http": {
@@ -21,8 +21,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19025",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20131"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19025",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20131"
       }
     }
   }

--- a/docs/testing/snippets/testing/xunit/AspireApp.AppHost/Properties/launchSettings.json
+++ b/docs/testing/snippets/testing/xunit/AspireApp.AppHost/Properties/launchSettings.json
@@ -9,8 +9,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21144",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22292"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21144",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22292"
       }
     },
     "http": {
@@ -21,8 +21,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19007",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20066"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19007",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20066"
       }
     }
   }

--- a/docs/troubleshooting/allow-unsecure-transport.md
+++ b/docs/troubleshooting/allow-unsecure-transport.md
@@ -1,7 +1,7 @@
 ---
 title: Allow unsecure transport in .NET Aspire
 description: Learn how to allow unsecure transport in .NET Aspire projects.
-ms.date: 04/09/2024
+ms.date: 04/15/2025
 ---
 
 # Allow unsecure transport in .NET Aspire
@@ -51,8 +51,8 @@ Alternatively, you can control this via the launch profile as it exposes the abi
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:16099",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:17037"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:16099",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:17037"
       }
     },
     "http": {
@@ -63,8 +63,8 @@ Alternatively, you can control this via the launch profile as it exposes the abi
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16099",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:17038",
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16099",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:17038",
         "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
       }
     }

--- a/docs/whats-new/dotnet-aspire-9.1.md
+++ b/docs/whats-new/dotnet-aspire-9.1.md
@@ -1,7 +1,7 @@
 ---
 title: What's new in .NET Aspire 9.1
 description: Learn what's new in the official general availability release of .NET Aspire 9.1.
-ms.date: 02/25/2025
+ms.date: 04/15/2025
 ---
 
 # What's new in .NET Aspire 9.1
@@ -107,7 +107,7 @@ For more information, see [.NET Aspire dashboard: Resources page](../fundamental
 
 ### 🛡️ CORS support for custom local domains
 
-You can now set the `DOTNET_DASHBOARD_CORS_ALLOWED_ORIGINS` environment variable to allow the dashboard to receive telemetry from other browser apps, such as if you have resources running on custom localhost domains.
+You can now set the `ASPIRE_DASHBOARD_CORS_ALLOWED_ORIGINS` environment variable to allow the dashboard to receive telemetry from other browser apps, such as if you have resources running on custom localhost domains.
 
 For more information, see [.NET Aspire app host: Dashboard configuration](../app-host/configuration.md#dashboard).
 


### PR DESCRIPTION
## Summary

Adjusts all the known .NET Aspire configuration variables to use the new `ASPIRE_` prefix instead of the old `DOTNET_` prefix.

Fixes #2901


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/app-host/configuration.md](https://github.com/dotnet/docs-aspire/blob/6bfb4ef6dac7fe47f0186d749970279302f1c690/docs/app-host/configuration.md) | [App host configuration](https://review.learn.microsoft.com/en-us/dotnet/aspire/app-host/configuration?branch=pr-en-us-3115) |
| [docs/fundamentals/dashboard/configuration.md](https://github.com/dotnet/docs-aspire/blob/6bfb4ef6dac7fe47f0186d749970279302f1c690/docs/fundamentals/dashboard/configuration.md) | [.NET Aspire dashboard configuration](https://review.learn.microsoft.com/en-us/dotnet/aspire/fundamentals/dashboard/configuration?branch=pr-en-us-3115) |
| [docs/fundamentals/dashboard/enable-browser-telemetry.md](https://github.com/dotnet/docs-aspire/blob/6bfb4ef6dac7fe47f0186d749970279302f1c690/docs/fundamentals/dashboard/enable-browser-telemetry.md) | [Enable browser telemetry](https://review.learn.microsoft.com/en-us/dotnet/aspire/fundamentals/dashboard/enable-browser-telemetry?branch=pr-en-us-3115) |
| [docs/fundamentals/dashboard/security-considerations.md](https://github.com/dotnet/docs-aspire/blob/6bfb4ef6dac7fe47f0186d749970279302f1c690/docs/fundamentals/dashboard/security-considerations.md) | [Security considerations for running the .NET Aspire dashboard](https://review.learn.microsoft.com/en-us/dotnet/aspire/fundamentals/dashboard/security-considerations?branch=pr-en-us-3115) |
| [docs/fundamentals/dashboard/standalone.md](https://github.com/dotnet/docs-aspire/blob/6bfb4ef6dac7fe47f0186d749970279302f1c690/docs/fundamentals/dashboard/standalone.md) | [docs/fundamentals/dashboard/standalone](https://review.learn.microsoft.com/en-us/dotnet/aspire/fundamentals/dashboard/standalone?branch=pr-en-us-3115) |
| [docs/fundamentals/launch-profiles.md](https://github.com/dotnet/docs-aspire/blob/6bfb4ef6dac7fe47f0186d749970279302f1c690/docs/fundamentals/launch-profiles.md) | [.NET Aspire and launch profiles](https://review.learn.microsoft.com/en-us/dotnet/aspire/fundamentals/launch-profiles?branch=pr-en-us-3115) |
| [docs/fundamentals/setup-tooling.md](https://github.com/dotnet/docs-aspire/blob/6bfb4ef6dac7fe47f0186d749970279302f1c690/docs/fundamentals/setup-tooling.md) | [.NET Aspire setup and tooling](https://review.learn.microsoft.com/en-us/dotnet/aspire/fundamentals/setup-tooling?branch=pr-en-us-3115) |
| [docs/troubleshooting/allow-unsecure-transport.md](https://github.com/dotnet/docs-aspire/blob/6bfb4ef6dac7fe47f0186d749970279302f1c690/docs/troubleshooting/allow-unsecure-transport.md) | [Allow unsecure transport in .NET Aspire](https://review.learn.microsoft.com/en-us/dotnet/aspire/troubleshooting/allow-unsecure-transport?branch=pr-en-us-3115) |
| [docs/whats-new/dotnet-aspire-9.1.md](https://github.com/dotnet/docs-aspire/blob/6bfb4ef6dac7fe47f0186d749970279302f1c690/docs/whats-new/dotnet-aspire-9.1.md) | [What's new in .NET Aspire 9.1](https://review.learn.microsoft.com/en-us/dotnet/aspire/whats-new/dotnet-aspire-9.1?branch=pr-en-us-3115) |

<!-- PREVIEW-TABLE-END -->