### PR TITLE
Fix the Python article

### DIFF
--- a/docs/get-started/build-aspire-apps-with-python.md
+++ b/docs/get-started/build-aspire-apps-with-python.md
@@ -1,7 +1,7 @@
 ---
 title: Orchestrate Python apps in .NET Aspire
 description: Learn how to integrate Python apps into a .NET Aspire app host project.
-ms.date: 11/11/2024
+ms.date: 04/15/2025
 ---
 
 # Orchestrate Python apps in .NET Aspire
@@ -12,11 +12,11 @@ In this article, you learn how to use Python apps in a .NET Aspire app host. The
 
 Additionally, you need to install [Python](https://www.python.org/downloads) on your machine. The sample app in this article was built with Python version 3.12.4 and pip version 24.1.2. To verify your Python and pip versions, run the following commands:
 
-```python
+```console
 python --version
 ```
 
-```python
+```console
 pip --version
 ```
 
@@ -24,7 +24,7 @@ To download Python (including `pip`), see the [Python download page](https://www
 
 ## Create a .NET Aspire project using the template
 
-To get started launching a Python project in .NET Aspire first use the starter template to create a .NET Aspire application host:
+To get started launching a Python project in .NET Aspire, use the starter template to first create a .NET Aspire application host:
 
 ```dotnetcli
 dotnet new aspire -o PythonSample
@@ -32,29 +32,29 @@ dotnet new aspire -o PythonSample
 
 In the same terminal session, change directories into the newly created project:
 
-```dotnetcli
+```console
 cd PythonSample
 ```
 
-Once the template has been created launch the app host with the following command to ensure that the app host and the [.NET Aspire dashboard](../fundamentals/dashboard/overview.md) launches successfully:
+After the template is created, launch the app host with the following command to ensure that the app host and the [.NET Aspire dashboard](../fundamentals/dashboard/overview.md) run successfully:
 
 ```dotnetcli
-dotnet run --project PythonSample.AppHost/PythonSample.AppHost.csproj
+dotnet run --project ./PythonSample.AppHost/PythonSample.AppHost.csproj
 ```
 
-Once the app host starts it should be possible to click on the dashboard link in the console output. At this point the dashboard will not show any resources. Stop the app host by pressing <kbd>Ctrl</kbd> + <kbd>C</kbd> in the terminal.
+If the .NET Aspire Dashboard doesn't open, open it with the link in the console output. At this point the dashboard won't show any resources. Stop the app host by pressing <kbd>Ctrl + C</kbd> in the terminal.
 
 ## Prepare a Python app
 
 From your previous terminal session where you created the .NET Aspire solution, create a new directory to contain the Python source code.
 
-```Console
+```console
 mkdir hello-python
 ```
 
 Change directories into the newly created _hello-python_ directory:
 
-```Console
+```console
 cd hello-python
 ```
 
@@ -62,7 +62,7 @@ cd hello-python
 
 To work with Python apps, they need to be within a virtual environment. To create a virtual environment, run the following command:
 
-```python
+```console
 python -m venv .venv
 ```
 
@@ -86,7 +86,7 @@ source .venv/bin/activate
 
 Ensure that pip within the virtual environment is up-to-date by running the following command:
 
-```python
+```console
 python -m pip install --upgrade pip
 ```
 
@@ -94,13 +94,13 @@ python -m pip install --upgrade pip
 
 Install the Flask package by creating a _requirements.txt_ file in the _hello-python_ directory and adding the following line:
 
-```python
+```text
 Flask==3.0.3
 ```
 
 Then, install the Flask package by running the following command:
 
-```python
+```console
 python -m pip install -r requirements.txt
 ```
 
@@ -131,16 +131,16 @@ Install the Python hosting package by running the following command:
 dotnet add ../PythonSample.AppHost/PythonSample.AppHost.csproj package Aspire.Hosting.Python --version 9.0.0
 ```
 
-After the package is installed, the project XML should have a new package reference similar to the following:
+After the package is installed, the project XML should have a new package reference similar to the following example:
 
-:::code language="xml" source="snippets/PythonSample/PythonSample.AppHost/PythonSample.AppHost.csproj":::
+:::code language="xml" source="snippets/PythonSample/PythonSample.AppHost/PythonSample.AppHost.csproj" highlight="15":::
 
-Update the app host _Program.cs_ file to include the Python project, by calling the `AddPythonApp` API and specifying the project name, project path, and the entry point file:
+Replace the app host _Program.cs_ code with the following snippet. This code adds the Python project to .NET Aspire by calling the `AddPythonApp` API and specifying the project name, project path, and the entry point file:
 
-:::code source="snippets/PythonSample/PythonSample.AppHost/Program.cs":::
+:::code source="snippets/PythonSample/PythonSample.AppHost/Program.cs" highlight="6":::
 
 > [!IMPORTANT]
-> The `AddPythonApp` API is experimental and may change in future releases. For more information, see [ASPIREHOSTINGPYTHON001](../diagnostics/overview.md#aspirehostingpython001).
+> The preceding code suppresses the `ASPIREHOSTINGPYTHON001` diagnostic error. This error is generated because the `AddPythonApp` API is experimental and might change in future release. For more information, see [ASPIREHOSTINGPYTHON001](../diagnostics/overview.md#aspirehostingpython001).
 
 ## Run the app
 
@@ -160,33 +160,36 @@ Select the **Endpoints** link to open the `hello-python` endpoint in a new brows
 
 Stop the app host by pressing <kbd>Ctrl</kbd> + <kbd>C</kbd> in the terminal.
 
-## Add telemetry support.
+## Add telemetry support
 
-To add a bit of observability, add telemetry to help monitor the dependant Python app. In the Python project, add the following OpenTelemetry package as a dependency in the _requirements.txt_ file:
+To add a bit of observability, add telemetry to help monitor the dependant Python app. In the Python project, add the following **OpenTelemetry** packages as a dependency in the _requirements.txt_ file:
 
-:::code language="python" source="snippets/PythonSample/hello-python/requirements.txt" highlight="2-5":::
+:::code language="text" source="snippets/PythonSample/hello-python/requirements.txt" highlight="2-5":::
 
-The preceding requirement update, adds the OpenTelemetry package and the OTLP exporter. Next, re-install the Python app requirements into the virtual environment by running the following command:
+Next, reinstall the Python app requirements into the virtual environment by running the following command:
 
-```python
+```console
 python -m pip install -r requirements.txt
 ```
 
-The preceding command installs the OpenTelemetry package and the OTLP exporter, in the virtual environment. Update the Python app to include the OpenTelemetry code, by replacing the existing _main.py_ code with the following:
+The preceding command installs the **OpenTelemetry** package and the **OTLP** exporter, in the virtual environment. Update the Python app to include the **OpenTelemetry** code, by replacing the existing _main.py_ code with the following:
 
 :::code language="python" source="snippets/PythonSample/hello-python/main.py":::
 
-Update the app host project's _launchSettings.json_ file to include the `ASPIRE_ALLOW_UNSECURED_TRANSPORT` environment variable:
+Update the app host project's _launchSettings.json_ file to include the `ASPIRE_ALLOW_UNSECURED_TRANSPORT` environment variable under the `http` profile:
 
-:::code language="json" source="snippets/PythonSample/PythonSample.AppHost/Properties/launchSettings.json":::
+:::code language="json" source="snippets/PythonSample/PythonSample.AppHost/Properties/launchSettings.json" highlight="26":::
 
 The `ASPIRE_ALLOW_UNSECURED_TRANSPORT` variable is required because when running locally the OpenTelemetry client in Python rejects the local development certificate. Launch the _app host_ again:
 
 ```dotnetcli
-dotnet run --project ../PythonSample.AppHost/PythonSample.AppHost.csproj
+dotnet run --project ../PythonSample.AppHost/PythonSample.AppHost.csproj --launch-profile http
 ```
 
-Once the app host has launched navigate to the dashboard and note that in addition to console log output, structured logging is also being routed through to the dashboard.
+> [!IMPORTANT]
+> The .NET Aspire host must be run using HTTP instead of HTTPS. The **OpenTelemetry** library requires HTTP when running in a local dev environment.
+
+Once the app host is running, navigate to the dashboard and select the **Structured** logging tab. Notice that it now contains logging events.
 
 :::image source="media/python-telemetry-in-dashboard.png" lightbox="media/python-telemetry-in-dashboard.png" alt-text=".NET Aspire dashboard: Structured logging from Python process.":::
 

--- a/docs/get-started/build-aspire-apps-with-python.md
+++ b/docs/get-started/build-aspire-apps-with-python.md
@@ -187,7 +187,7 @@ dotnet run --project ../PythonSample.AppHost/PythonSample.AppHost.csproj --launc
 ```
 
 > [!IMPORTANT]
-> The .NET Aspire host must be run using HTTP instead of HTTPS. The **OpenTelemetry** library requires HTTP when running in a local dev environment.
+> The .NET Aspire app host must be run using HTTP instead of HTTPS. The **OpenTelemetry** library requires HTTP when running in a local dev environment.
 
 Once the app host is running, navigate to the dashboard and select the **Structured** logging tab. Notice that it now contains logging events.
 


### PR DESCRIPTION
## Summary

- Add instructions to run the app as HTTP which is required for the OpenTelemetry package to work via Python on a local dev box.
- Adjust some of the code block identifiers.
- Improve acro score from 88 to 95.
- Add some extra code highlighters where appropriate.

Fixes #3076


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/get-started/build-aspire-apps-with-python.md](https://github.com/dotnet/docs-aspire/blob/012d770ad7bf093168e8f4a43cd3551403ab9faf/docs/get-started/build-aspire-apps-with-python.md) | [docs/get-started/build-aspire-apps-with-python](https://review.learn.microsoft.com/en-us/dotnet/aspire/get-started/build-aspire-apps-with-python?branch=pr-en-us-3117) |


<!-- PREVIEW-TABLE-END -->