### PR TITLE
fixes #3085 Simple example for configuring the container apps environment

### DIFF
--- a/docs/azure/configure-aca-environments.md
+++ b/docs/azure/configure-aca-environments.md
@@ -66,9 +66,11 @@ Calling this API ensures your existing Azure resources remain consistent and pre
 
 ## Customize provisioning infrastructure
 
-All .NET Aspire Azure resources are subclasses of the <xref:Aspire.Hosting.Azure.AzureProvisioningResource> type. This enables customization of the generated Bicep by providing a fluent API to configure the Azure resources—using the <xref:Aspire.Hosting.AzureProvisioningResourceExtensions.ConfigureInfrastructure``1(Aspire.Hosting.ApplicationModel.IResourceBuilder{``0},System.Action{Aspire.Hosting.Azure.AzureResourceInfrastructure})> API:
+All .NET Aspire Azure resources are subclasses of the <xref:Aspire.Hosting.Azure.AzureProvisioningResource> type. This enables customization of the generated Bicep by providing a fluent API to configure the Azure resourcesâ€”using the <xref:Aspire.Hosting.AzureProvisioningResourceExtensions.ConfigureInfrastructure``1(Aspire.Hosting.ApplicationModel.IResourceBuilder{``0},System.Action{Aspire.Hosting.Azure.AzureResourceInfrastructure})> API:
 
 ```csharp
+var builder = DistributionApplicationBuilder.Create(args);
+
 var acaEnv = builder.AddAzureContainerAppEnvironment(Config.ContainEnvironmentName);
 
 acaEnv.ConfigureInfrastructure(config =>

--- a/docs/azure/configure-aca-environments.md
+++ b/docs/azure/configure-aca-environments.md
@@ -64,6 +64,30 @@ builder.Build().Run();
 
 Calling this API ensures your existing Azure resources remain consistent and prevents duplication.
 
+## Customize provisioning infrastructure
+
+All .NET Aspire Azure resources are subclasses of the <xref:Aspire.Hosting.Azure.AzureProvisioningResource> type. This enables customization of the generated Bicep by providing a fluent API to configure the Azure resources—using the <xref:Aspire.Hosting.AzureProvisioningResourceExtensions.ConfigureInfrastructure``1(Aspire.Hosting.ApplicationModel.IResourceBuilder{``0},System.Action{Aspire.Hosting.Azure.AzureResourceInfrastructure})> API:
+
+```csharp
+var acaEnv = builder.AddAzureContainerAppEnvironment(Config.ContainEnvironmentName);
+
+acaEnv.ConfigureInfrastructure(config =>
+{
+    var resources = config.GetProvisionableResources();
+    var containerEnvironment = resources.OfType<ContainerAppManagedEnvironment>().FirstOrDefault();
+
+    containerEnvironment.Tags.Add("ExampleKey", "Example value");
+});
+```
+
+The preceding code:
+
+- Chains a call to the <xref:Aspire.Hosting.AzureProvisioningResourceExtensions.ConfigureInfrastructure*> API:
+  - The `infra` parameter is an instance of the <xref:Aspire.Hosting.Azure.AzureResourceInfrastructure> type.
+  - The provisionable resources are retrieved by calling the <xref:Azure.Provisioning.Infrastructure.GetProvisionableResources> method.
+  - The single <xref:Azure.Provisioning.AppContainers.ContainerAppManagedEnvironment> resource is retrieved.
+  - A tag is added to the Azure Container Apps environment resource with a key of `ExampleKey` and a value of `Example value`.
+
 ## See also
 
 - [.NET Aspire Azure integrations overview](integrations-overview.md)


### PR DESCRIPTION
## Summary

Modified existing 'configure-aca-environments.md' to provide simple example of configuring the container apps environment in Program.cs of the Aspire AppHost, using 'ConfigureInfrastructure' and getting the provisionable resource of type 'ContainerAppManagedEnvironment'.

fixes #3085


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/azure/configure-aca-environments.md](https://github.com/dotnet/docs-aspire/blob/8017de83958bfda19135ee2d2fed86c6d2ceb6cf/docs/azure/configure-aca-environments.md) | [Configure Azure Container Apps environments](https://review.learn.microsoft.com/en-us/dotnet/aspire/azure/configure-aca-environments?branch=pr-en-us-3119) |


<!-- PREVIEW-TABLE-END -->