### PR TITLE
Redesign diagnostic template

### DIFF
--- a/.github/ISSUE_TEMPLATE/06-diagnostic-addition.yml
+++ b/.github/ISSUE_TEMPLATE/06-diagnostic-addition.yml
@@ -39,14 +39,6 @@ body:
   validations:
     required: true
 
-- type: textarea
-  id: description
-  attributes:
-    label: Description
-    description: Describe why the diagnostic exists and what it's used to indicate.
-  validations:
-    required: true
-
 - type: input
   id: title-short
   attributes:

--- a/.github/ISSUE_TEMPLATE/06-diagnostic-addition.yml
+++ b/.github/ISSUE_TEMPLATE/06-diagnostic-addition.yml
@@ -35,7 +35,7 @@ body:
   id: version_introduced
   attributes:
     label: Version Introduced
-    description: "What version of .NET was this introduced with? (ex: 8 or something like 10 Preview 3)"
+    description: "What version of .NET Aspire was this introduced with? (ex: 9.2)"
   validations:
     required: true
 

--- a/.github/ISSUE_TEMPLATE/06-diagnostic-addition.yml
+++ b/.github/ISSUE_TEMPLATE/06-diagnostic-addition.yml
@@ -32,6 +32,14 @@ body:
     required: true
 
 - type: input
+  id: version_introduced
+  attributes:
+    label: Version Introduced
+    description: "What version of .NET was this introduced with? (ex: 8 or something like 10 Preview 3)"
+  validations:
+    required: true
+
+- type: input
   id: diagnostic-id
   attributes:
     label: Diagnostic ID

--- a/.github/ISSUE_TEMPLATE/06-diagnostic-addition.yml
+++ b/.github/ISSUE_TEMPLATE/06-diagnostic-addition.yml
@@ -23,7 +23,7 @@ body:
 - type: dropdown
   id: type
   attributes:
-    label: Default Reporting Scope
+    label: Rule Type
     description: "Is this considered an error or warning?"
     options:
       - Error

--- a/.github/ISSUE_TEMPLATE/06-diagnostic-addition.yml
+++ b/.github/ISSUE_TEMPLATE/06-diagnostic-addition.yml
@@ -6,8 +6,31 @@ labels:
 - doc-idea
 - area-docs
 assignees:
-- IEvangelist
+- adegeo
 body:
+- type: markdown
+  attributes:
+    value: |
+      ```
+      ┌───────────┐
+      │ IMPORTANT ├──────────────────────────┐
+      └────────┬──┘ Please read the          │
+               │       following statement   │
+               └─────────────────────────────┘
+      ```
+      This template is for use by the product team to request new compiler warning articles.
+
+- type: dropdown
+  id: type
+  attributes:
+    label: Default Reporting Scope
+    description: "Is this considered an error or warning?"
+    options:
+      - Error
+      - Warning
+  validations:
+    required: true
+
 - type: input
   id: diagnostic-id
   attributes:
@@ -15,10 +38,35 @@ body:
     description: Enter the ID of the diagnostic to be added. Used for headings, i.e.; `ASPIREACADOMAINS001`.
   validations:
     required: true
+
 - type: textarea
   id: description
   attributes:
     label: Description
     description: Describe why the diagnostic exists and what it's used to indicate.
+  validations:
+    required: true
+
+- type: input
+  id: title-short
+  attributes:
+    label: Short Title
+    description: "A simple title in one sentence that describes the rule. If possible, use the error/warning a user sees."
+  validations:
+    required: true
+
+- type: textarea
+  id: description
+  attributes:
+    label: Description
+    description: "Summarize what triggers this. Provide code examples if applicable."
+  validations:
+    required: true
+
+- type: textarea
+  id: fix
+  attributes:
+    label: How to fix
+    description: "Summarize what a user does to avoid triggering the rule, or what they do to fix their code. Provide an example if possible."
   validations:
     required: true


### PR DESCRIPTION
## Summary

Discuss!

- Fun intro box
- Add field to indicate error or warning
- Add short title, hopefully engineer will paste in the actual error text a user sees.
- Keep Description
- Add possible fix
- Add version introduced

Preview: https://github.com/dotnet/docs-aspire/blob/adegeo/github/diagnostic/.github/ISSUE_TEMPLATE/06-diagnostic-addition.yml

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [.github/ISSUE_TEMPLATE/06-diagnostic-addition.yml](https://github.com/dotnet/docs-aspire/blob/998ccb06dd551ab115d2b593199d7a26a31d85d1/.github/ISSUE_TEMPLATE/06-diagnostic-addition.yml) | [.github/ISSUE_TEMPLATE/06-diagnostic-addition](https://review.learn.microsoft.com/en-us/dotnet/aspire/.github/ISSUE_TEMPLATE/06-diagnostic-addition?branch=pr-en-us-3127) |


<!-- PREVIEW-TABLE-END -->