### PR TITLE
Add missing Orleans interface

### DIFF
--- a/docs/frameworks/orleans.md
+++ b/docs/frameworks/orleans.md
@@ -124,6 +124,10 @@ The following code is a complete example of an Orleans server project, including
 
 :::code language="csharp" source="snippets/Orleans/OrleansServer/Program.cs" :::
 
+The `CounterGrain` is an implementation of the following `ICounterGrain` interface, which is defined in the shared _OrleansContracts_ project:
+
+:::code language="csharp" source="snippets/Orleans/OrleansContracts/ICounterGrain.cs" :::
+
 ## Create an Orleans client project
 
 In the Orleans client project, add the same NuGet packages:


### PR DESCRIPTION
## Summary

Add the missing contract/interface.

Fixes #3132


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/frameworks/orleans.md](https://github.com/dotnet/docs-aspire/blob/fc0ee2ad6ba22886d0758cc54abbe1159a42e93b/docs/frameworks/orleans.md) | [.NET Aspire Orleans integration](https://review.learn.microsoft.com/en-us/dotnet/aspire/frameworks/orleans?branch=pr-en-us-3134) |

<!-- PREVIEW-TABLE-END -->