### PR TITLE
Add dev-cert details to templates content

### DIFF
--- a/docs/fundamentals/aspire-sdk-templates.md
+++ b/docs/fundamentals/aspire-sdk-templates.md
@@ -109,7 +109,7 @@ dotnet new aspire-starter
 > dotnet new aspire-apphost --framework net8.0
 > ```
 
-You need to trust the ASP.NET Core localhost certificate before running the app. Run the following command:
+You need to trust the ASP.NET Core :::no-loc text="localhost"::: certificate before running the app. Run the following command:
 
 ```dotnetcli
 dotnet dev-certs https --trust

--- a/docs/fundamentals/aspire-sdk-templates.md
+++ b/docs/fundamentals/aspire-sdk-templates.md
@@ -109,6 +109,14 @@ dotnet new aspire-starter
 > dotnet new aspire-apphost --framework net8.0
 > ```
 
+You need to trust the ASP.NET Core localhost certificate before running the app. Run the following command:
+
+```dotnetcli
+dotnet dev-certs https --trust
+```
+
+For more information, see [Troubleshoot untrusted localhost certificate in .NET Aspire](../troubleshooting/untrusted-localhost-certificate.md). For in-depth details about troubleshooting localhost certificates on Linux, see [ASP.NET Core: GitHub repository issue #32842](https://github.com/dotnet/aspnetcore/issues/32842).
+
 :::zone-end
 
 ## See also


### PR DESCRIPTION
## Summary

Add dev-cert details to templates content.

Fixes #3135


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/aspire-sdk-templates.md](https://github.com/dotnet/docs-aspire/blob/cdffe26fc62acc264ff233a296c0616430d3a141/docs/fundamentals/aspire-sdk-templates.md) | [.NET Aspire templates](https://review.learn.microsoft.com/en-us/dotnet/aspire/fundamentals/aspire-sdk-templates?branch=pr-en-us-3136) |


<!-- PREVIEW-TABLE-END -->