### PR TITLE
fix: update Service Bus SKU property from Tier to Name

### DIFF
--- a/docs/snippets/azure/AppHost/Program.ConfigureServiceBusInfra.cs
+++ b/docs/snippets/azure/AppHost/Program.ConfigureServiceBusInfra.cs
@@ -14,7 +14,7 @@ internal static partial class Program
 
                 serviceBusNamespace.Sku = new ServiceBusSku
                 {
-                    Tier = ServiceBusSkuTier.Premium
+                    Name = ServiceBusSkuName.Premium
                 };
                 serviceBusNamespace.Tags.Add("ExampleKey", "Example value");
             });


### PR DESCRIPTION
## Summary

The ConfigureServiceBusInfra snippet uses the Tier property to configure the Sku but this generates incorrect bicep when trying to deploy via azd and azure publisher. It should use the Name property instead.

Fixes https://github.com/dotnet/docs-aspire/issues/3158
