### PR TITLE
Add ReferenceExpression to the External Parameters article

### DIFF
--- a/docs/fundamentals/external-parameters.md
+++ b/docs/fundamentals/external-parameters.md
@@ -134,10 +134,14 @@ var builder = DistributedApplication.CreateBuilder(args);
 var redis = builder.AddConnectionString("redis");
 
 builder.AddProject<Projects.WebApplication>("api")
-       .WithReference(redis);
+       .WithReference(redis)
+       .WaitFor(redis);
 
 builder.Build().Run();
 ```
+
+> [!NOTE]
+> Using <xref:Aspire.Hosting.ResourceBuilderExtensions.WaitFor*> with a connection string will implicitly wait for the resource that the connection string connects to.
 
 Now consider the following app host configuration file _:::no-loc text="appsettings.json":::_:
 
@@ -150,6 +154,43 @@ Now consider the following app host configuration file _:::no-loc text="appsetti
 ```
 
 For more information pertaining to connection strings and their representation in the deployment manifest, see [Connection string and binding references](../deployment/manifest-format.md#connection-string-and-binding-references).
+
+### Build connection strings with reference expressions
+
+If you want to construct a connection string from parameters and ensure that it's handled correctly in both development and production, use <xref:Aspire.Hosting.ConnectionStringBuilderExtensions.AddConnectionString*> with a <xref:Aspire.Hosting.ApplicationModel.ReferenceExpression>. 
+
+For example, if you have a secret parameter that stores a small part of a connection string, use this code to insert it:
+
+```csharp
+var builder = DistributedApplication.CreateBuilder(args);
+
+var secretKey = builder.AddParameter("secretkey", secret: true);
+
+var connectionString  = builder.AddConnectionString("composedconnectionstring", ReferenceExpression.Create($"Endpoint=https://api.contoso.com/v1;Key={secretKey}"));
+
+builder.AddProject<Projects.WebApplication>("api")
+       .WithReference(connectionString)
+       .WaitFor(connectionString);
+
+builder.Build().Run();
+```
+
+You can also use reference expressions to append text to connection strings created by .NET Aspire resources. For example, when you add a PostgreSQL resource to your .NET Aspire solution, the database server runs in a container and a connection string is formulated for it. In the following code, the extra property `Include Error Details` is appended to that connection string before it's passed to consuming projects:
+
+```csharp
+var builder = DistributedApplication.CreateBuilder(args);
+
+var postgres = builder.AddPostgres("postgres")
+var database = postgres.AddDatabase("db");
+
+var pgConnectionString = builder.AddConnectionString("pgdatabase", ReferenceExpression.Create($"{database};Include Error Details=true"));
+
+builder.AddProject<Projects.WebApplication>("api")
+       .WithReference(pgConnectionString)
+       .WaitFor(pgConnectionString);
+
+builder.Build().Run();
+```
 
 ## Parameter example
 

--- a/docs/fundamentals/external-parameters.md
+++ b/docs/fundamentals/external-parameters.md
@@ -161,36 +161,11 @@ If you want to construct a connection string from parameters and ensure that it'
 
 For example, if you have a secret parameter that stores a small part of a connection string, use this code to insert it:
 
-```csharp
-var builder = DistributedApplication.CreateBuilder(args);
-
-var secretKey = builder.AddParameter("secretkey", secret: true);
-
-var connectionString  = builder.AddConnectionString("composedconnectionstring", ReferenceExpression.Create($"Endpoint=https://api.contoso.com/v1;Key={secretKey}"));
-
-builder.AddProject<Projects.WebApplication>("api")
-       .WithReference(connectionString)
-       .WaitFor(connectionString);
-
-builder.Build().Run();
-```
+:::code language="csharp" source="snippets/referenceexpressions/AspireReferenceExpressions.AppHost/Program.cs" range="1-5,16-20":::
 
 You can also use reference expressions to append text to connection strings created by .NET Aspire resources. For example, when you add a PostgreSQL resource to your .NET Aspire solution, the database server runs in a container and a connection string is formulated for it. In the following code, the extra property `Include Error Details` is appended to that connection string before it's passed to consuming projects:
 
-```csharp
-var builder = DistributedApplication.CreateBuilder(args);
-
-var postgres = builder.AddPostgres("postgres")
-var database = postgres.AddDatabase("db");
-
-var pgConnectionString = builder.AddConnectionString("pgdatabase", ReferenceExpression.Create($"{database};Include Error Details=true"));
-
-builder.AddProject<Projects.WebApplication>("api")
-       .WithReference(pgConnectionString)
-       .WaitFor(pgConnectionString);
-
-builder.Build().Run();
-```
+:::code language="csharp" source="snippets/referenceexpressions/AspireReferenceExpressions.AppHost/Program.cs" range="1,7-14,20":::
 
 ## Parameter example
 

--- a/docs/fundamentals/snippets/referenceexpressions/AspireReferenceExpressions.API/AspireReferenceExpressions.API.csproj
+++ b/docs/fundamentals/snippets/referenceexpressions/AspireReferenceExpressions.API/AspireReferenceExpressions.API.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AspireReferenceExpressions.ServiceDefaults\AspireReferenceExpressions.ServiceDefaults.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/docs/fundamentals/snippets/referenceexpressions/AspireReferenceExpressions.API/AspireReferenceExpressions.API.http
+++ b/docs/fundamentals/snippets/referenceexpressions/AspireReferenceExpressions.API/AspireReferenceExpressions.API.http
@@ -1,0 +1,6 @@
+@AspireReferenceExpressions.API_HostAddress = http://localhost:5222
+
+GET {{AspireReferenceExpressions.API_HostAddress}}/weatherforecast/
+Accept: application/json
+
+###

--- a/docs/fundamentals/snippets/referenceexpressions/AspireReferenceExpressions.API/Controllers/WeatherForecastController.cs
+++ b/docs/fundamentals/snippets/referenceexpressions/AspireReferenceExpressions.API/Controllers/WeatherForecastController.cs
@@ -1,0 +1,32 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace AspireReferenceExpressions.API.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+public class WeatherForecastController : ControllerBase
+{
+    private static readonly string[] Summaries = new[]
+    {
+        "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+    };
+
+    private readonly ILogger<WeatherForecastController> _logger;
+
+    public WeatherForecastController(ILogger<WeatherForecastController> logger)
+    {
+        _logger = logger;
+    }
+
+    [HttpGet(Name = "GetWeatherForecast")]
+    public IEnumerable<WeatherForecast> Get()
+    {
+        return Enumerable.Range(1, 5).Select(index => new WeatherForecast
+        {
+            Date = DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
+            TemperatureC = Random.Shared.Next(-20, 55),
+            Summary = Summaries[Random.Shared.Next(Summaries.Length)]
+        })
+        .ToArray();
+    }
+}

--- a/docs/fundamentals/snippets/referenceexpressions/AspireReferenceExpressions.API/Program.cs
+++ b/docs/fundamentals/snippets/referenceexpressions/AspireReferenceExpressions.API/Program.cs
@@ -1,0 +1,27 @@
+var builder = WebApplication.CreateBuilder(args);
+
+builder.AddServiceDefaults();
+
+// Add services to the container.
+
+builder.Services.AddControllers();
+// Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
+builder.Services.AddOpenApi();
+
+var app = builder.Build();
+
+app.MapDefaultEndpoints();
+
+// Configure the HTTP request pipeline.
+if (app.Environment.IsDevelopment())
+{
+    app.MapOpenApi();
+}
+
+app.UseHttpsRedirection();
+
+app.UseAuthorization();
+
+app.MapControllers();
+
+app.Run();

--- a/docs/fundamentals/snippets/referenceexpressions/AspireReferenceExpressions.API/Properties/launchSettings.json
+++ b/docs/fundamentals/snippets/referenceexpressions/AspireReferenceExpressions.API/Properties/launchSettings.json
@@ -1,0 +1,23 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:5222",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "https://localhost:7080;http://localhost:5222",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/docs/fundamentals/snippets/referenceexpressions/AspireReferenceExpressions.API/WeatherForecast.cs
+++ b/docs/fundamentals/snippets/referenceexpressions/AspireReferenceExpressions.API/WeatherForecast.cs
@@ -1,0 +1,12 @@
+namespace AspireReferenceExpressions.API;
+
+public class WeatherForecast
+{
+    public DateOnly Date { get; set; }
+
+    public int TemperatureC { get; set; }
+
+    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+
+    public string? Summary { get; set; }
+}

--- a/docs/fundamentals/snippets/referenceexpressions/AspireReferenceExpressions.API/appsettings.Development.json
+++ b/docs/fundamentals/snippets/referenceexpressions/AspireReferenceExpressions.API/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/docs/fundamentals/snippets/referenceexpressions/AspireReferenceExpressions.API/appsettings.json
+++ b/docs/fundamentals/snippets/referenceexpressions/AspireReferenceExpressions.API/appsettings.json
@@ -1,0 +1,12 @@
+{
+    "Parameters": {
+        "secretkey": "12345"
+    },
+    "Logging": {
+        "LogLevel": {
+            "Default": "Information",
+            "Microsoft.AspNetCore": "Warning"
+        }
+    },
+    "AllowedHosts": "*"
+}

--- a/docs/fundamentals/snippets/referenceexpressions/AspireReferenceExpressions.AppHost/AspireReferenceExpressions.AppHost.csproj
+++ b/docs/fundamentals/snippets/referenceexpressions/AspireReferenceExpressions.AppHost/AspireReferenceExpressions.AppHost.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Sdk Name="Aspire.AppHost.Sdk" Version="9.2.0" />
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <UserSecretsId>b0c3a3ac-dab2-4d43-a991-70bcb70215ba</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.2.0" />
+    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="9.2.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AspireReferenceExpressions.API\AspireReferenceExpressions.API.csproj" />
+    <ProjectReference Include="..\AspireReferenceExpressions.Web\AspireReferenceExpressions.Web.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/docs/fundamentals/snippets/referenceexpressions/AspireReferenceExpressions.AppHost/Program.cs
+++ b/docs/fundamentals/snippets/referenceexpressions/AspireReferenceExpressions.AppHost/Program.cs
@@ -1,0 +1,20 @@
+﻿var builder = DistributedApplication.CreateBuilder(args);
+
+var secretKey = builder.AddParameter("secretkey", secret: true);
+
+var connectionString = builder.AddConnectionString("composedconnectionstring", ReferenceExpression.Create($"Endpoint=https://api.contoso.com/v1;Key={secretKey}"));
+
+var postgres = builder.AddPostgres("postgres");
+var database = postgres.AddDatabase("db");
+
+var pgConnectionString = builder.AddConnectionString("pgdatabase", ReferenceExpression.Create($"{database};Include Error Details=true"));
+
+builder.AddProject<Projects.AspireReferenceExpressions_Web>("web")
+       .WithReference(pgConnectionString)
+       .WaitFor(pgConnectionString);
+
+builder.AddProject<Projects.AspireReferenceExpressions_API>("api")
+       .WithReference(connectionString)
+       .WaitFor(connectionString);
+
+builder.Build().Run();

--- a/docs/fundamentals/snippets/referenceexpressions/AspireReferenceExpressions.AppHost/Program.cs~
+++ b/docs/fundamentals/snippets/referenceexpressions/AspireReferenceExpressions.AppHost/Program.cs~
@@ -1,0 +1,20 @@
+﻿var builder = DistributedApplication.CreateBuilder(args);
+
+var secretKey = builder.AddParameter("secretkey", secret: true);
+
+var connectionString = builder.AddConnectionString("composedconnectionstring", ReferenceExpression.Create($"Endpoint=https://api.contoso.com/v1;Key={secretKey}"));
+
+var postgres = builder.AddPostgres("postgres");
+var database = postgres.AddDatabase("db");
+
+var pgConnectionString = builder.AddConnectionString("pgdatabase", ReferenceExpression.Create($"{database};Include Error Details=true"));
+
+builder.AddProject<Projects.AspireReferenceExpressions_API>("api")
+       .WithReference(connectionString)
+       .WaitFor(connectionString);
+
+builder.AddProject<Projects.AspireReferenceExpressions_Web>("web")
+       .WithReference(pgConnectionString)
+       .WaitFor(pgConnectionString);
+
+builder.Build().Run();

--- a/docs/fundamentals/snippets/referenceexpressions/AspireReferenceExpressions.AppHost/Properties/launchSettings.json
+++ b/docs/fundamentals/snippets/referenceexpressions/AspireReferenceExpressions.AppHost/Properties/launchSettings.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:17135;http://localhost:15179",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21013",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22297"
+      }
+    },
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:15179",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19288",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20017"
+      }
+    }
+  }
+}

--- a/docs/fundamentals/snippets/referenceexpressions/AspireReferenceExpressions.AppHost/appsettings.Development.json
+++ b/docs/fundamentals/snippets/referenceexpressions/AspireReferenceExpressions.AppHost/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/docs/fundamentals/snippets/referenceexpressions/AspireReferenceExpressions.AppHost/appsettings.json
+++ b/docs/fundamentals/snippets/referenceexpressions/AspireReferenceExpressions.AppHost/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "Aspire.Hosting.Dcp": "Warning"
+    }
+  }
+}

--- a/docs/fundamentals/snippets/referenceexpressions/AspireReferenceExpressions.ServiceDefaults/AspireReferenceExpressions.ServiceDefaults.csproj
+++ b/docs/fundamentals/snippets/referenceexpressions/AspireReferenceExpressions.ServiceDefaults/AspireReferenceExpressions.ServiceDefaults.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsAspireSharedProject>true</IsAspireSharedProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.4.0" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.2.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.2" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.11.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.11.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.11.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.11.1" />
+  </ItemGroup>
+
+</Project>

--- a/docs/fundamentals/snippets/referenceexpressions/AspireReferenceExpressions.ServiceDefaults/Extensions.cs
+++ b/docs/fundamentals/snippets/referenceexpressions/AspireReferenceExpressions.ServiceDefaults/Extensions.cs
@@ -1,0 +1,127 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.ServiceDiscovery;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
+namespace Microsoft.Extensions.Hosting;
+
+// Adds common .NET Aspire services: service discovery, resilience, health checks, and OpenTelemetry.
+// This project should be referenced by each service project in your solution.
+// To learn more about using this project, see https://aka.ms/dotnet/aspire/service-defaults
+public static class Extensions
+{
+    private const string HealthEndpointPath = "/health";
+    private const string AlivenessEndpointPath = "/alive";
+
+    public static TBuilder AddServiceDefaults<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
+    {
+        builder.ConfigureOpenTelemetry();
+
+        builder.AddDefaultHealthChecks();
+
+        builder.Services.AddServiceDiscovery();
+
+        builder.Services.ConfigureHttpClientDefaults(http =>
+        {
+            // Turn on resilience by default
+            http.AddStandardResilienceHandler();
+
+            // Turn on service discovery by default
+            http.AddServiceDiscovery();
+        });
+
+        // Uncomment the following to restrict the allowed schemes for service discovery.
+        // builder.Services.Configure<ServiceDiscoveryOptions>(options =>
+        // {
+        //     options.AllowedSchemes = ["https"];
+        // });
+
+        return builder;
+    }
+
+    public static TBuilder ConfigureOpenTelemetry<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
+    {
+        builder.Logging.AddOpenTelemetry(logging =>
+        {
+            logging.IncludeFormattedMessage = true;
+            logging.IncludeScopes = true;
+        });
+
+        builder.Services.AddOpenTelemetry()
+            .WithMetrics(metrics =>
+            {
+                metrics.AddAspNetCoreInstrumentation()
+                    .AddHttpClientInstrumentation()
+                    .AddRuntimeInstrumentation();
+            })
+            .WithTracing(tracing =>
+            {
+                tracing.AddSource(builder.Environment.ApplicationName)
+                    .AddAspNetCoreInstrumentation(tracing =>
+                        // Exclude health check requests from tracing
+                        tracing.Filter = context =>
+                            !context.Request.Path.StartsWithSegments(HealthEndpointPath)
+                            && !context.Request.Path.StartsWithSegments(AlivenessEndpointPath)
+                    )
+                    // Uncomment the following line to enable gRPC instrumentation (requires the OpenTelemetry.Instrumentation.GrpcNetClient package)
+                    //.AddGrpcClientInstrumentation()
+                    .AddHttpClientInstrumentation();
+            });
+
+        builder.AddOpenTelemetryExporters();
+
+        return builder;
+    }
+
+    private static TBuilder AddOpenTelemetryExporters<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
+    {
+        var useOtlpExporter = !string.IsNullOrWhiteSpace(builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"]);
+
+        if (useOtlpExporter)
+        {
+            builder.Services.AddOpenTelemetry().UseOtlpExporter();
+        }
+
+        // Uncomment the following lines to enable the Azure Monitor exporter (requires the Azure.Monitor.OpenTelemetry.AspNetCore package)
+        //if (!string.IsNullOrEmpty(builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"]))
+        //{
+        //    builder.Services.AddOpenTelemetry()
+        //       .UseAzureMonitor();
+        //}
+
+        return builder;
+    }
+
+    public static TBuilder AddDefaultHealthChecks<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
+    {
+        builder.Services.AddHealthChecks()
+            // Add a default liveness check to ensure app is responsive
+            .AddCheck("self", () => HealthCheckResult.Healthy(), ["live"]);
+
+        return builder;
+    }
+
+    public static WebApplication MapDefaultEndpoints(this WebApplication app)
+    {
+        // Adding health checks endpoints to applications in non-development environments has security implications.
+        // See https://aka.ms/dotnet/aspire/healthchecks for details before enabling these endpoints in non-development environments.
+        if (app.Environment.IsDevelopment())
+        {
+            // All health checks must pass for app to be considered ready to accept traffic after starting
+            app.MapHealthChecks(HealthEndpointPath);
+
+            // Only health checks tagged with the "live" tag must pass for app to be considered alive
+            app.MapHealthChecks(AlivenessEndpointPath, new HealthCheckOptions
+            {
+                Predicate = r => r.Tags.Contains("live")
+            });
+        }
+
+        return app;
+    }
+}

--- a/docs/fundamentals/snippets/referenceexpressions/AspireReferenceExpressions.Web/AspireReferenceExpressions.Web.csproj
+++ b/docs/fundamentals/snippets/referenceexpressions/AspireReferenceExpressions.Web/AspireReferenceExpressions.Web.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AspireReferenceExpressions.ServiceDefaults\AspireReferenceExpressions.ServiceDefaults.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/docs/fundamentals/snippets/referenceexpressions/AspireReferenceExpressions.Web/AspireReferenceExpressions.Web.http
+++ b/docs/fundamentals/snippets/referenceexpressions/AspireReferenceExpressions.Web/AspireReferenceExpressions.Web.http
@@ -1,0 +1,6 @@
+@AspireReferenceExpressions.Web_HostAddress = http://localhost:5157
+
+GET {{AspireReferenceExpressions.Web_HostAddress}}/weatherforecast/
+Accept: application/json
+
+###

--- a/docs/fundamentals/snippets/referenceexpressions/AspireReferenceExpressions.Web/Controllers/WeatherForecastController.cs
+++ b/docs/fundamentals/snippets/referenceexpressions/AspireReferenceExpressions.Web/Controllers/WeatherForecastController.cs
@@ -1,0 +1,32 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace AspireReferenceExpressions.Web.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+public class WeatherForecastController : ControllerBase
+{
+    private static readonly string[] Summaries = new[]
+    {
+        "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+    };
+
+    private readonly ILogger<WeatherForecastController> _logger;
+
+    public WeatherForecastController(ILogger<WeatherForecastController> logger)
+    {
+        _logger = logger;
+    }
+
+    [HttpGet(Name = "GetWeatherForecast")]
+    public IEnumerable<WeatherForecast> Get()
+    {
+        return Enumerable.Range(1, 5).Select(index => new WeatherForecast
+        {
+            Date = DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
+            TemperatureC = Random.Shared.Next(-20, 55),
+            Summary = Summaries[Random.Shared.Next(Summaries.Length)]
+        })
+        .ToArray();
+    }
+}

--- a/docs/fundamentals/snippets/referenceexpressions/AspireReferenceExpressions.Web/Program.cs
+++ b/docs/fundamentals/snippets/referenceexpressions/AspireReferenceExpressions.Web/Program.cs
@@ -1,0 +1,23 @@
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+
+builder.Services.AddControllers();
+// Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
+builder.Services.AddOpenApi();
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+if (app.Environment.IsDevelopment())
+{
+    app.MapOpenApi();
+}
+
+app.UseHttpsRedirection();
+
+app.UseAuthorization();
+
+app.MapControllers();
+
+app.Run();

--- a/docs/fundamentals/snippets/referenceexpressions/AspireReferenceExpressions.Web/Properties/launchSettings.json
+++ b/docs/fundamentals/snippets/referenceexpressions/AspireReferenceExpressions.Web/Properties/launchSettings.json
@@ -1,0 +1,23 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:5157",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "https://localhost:7025;http://localhost:5157",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/docs/fundamentals/snippets/referenceexpressions/AspireReferenceExpressions.Web/WeatherForecast.cs
+++ b/docs/fundamentals/snippets/referenceexpressions/AspireReferenceExpressions.Web/WeatherForecast.cs
@@ -1,0 +1,12 @@
+namespace AspireReferenceExpressions.Web;
+
+public class WeatherForecast
+{
+    public DateOnly Date { get; set; }
+
+    public int TemperatureC { get; set; }
+
+    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+
+    public string? Summary { get; set; }
+}

--- a/docs/fundamentals/snippets/referenceexpressions/AspireReferenceExpressions.Web/appsettings.Development.json
+++ b/docs/fundamentals/snippets/referenceexpressions/AspireReferenceExpressions.Web/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/docs/fundamentals/snippets/referenceexpressions/AspireReferenceExpressions.Web/appsettings.json
+++ b/docs/fundamentals/snippets/referenceexpressions/AspireReferenceExpressions.Web/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/docs/fundamentals/snippets/referenceexpressions/AspireReferenceExpressions.sln
+++ b/docs/fundamentals/snippets/referenceexpressions/AspireReferenceExpressions.sln
@@ -1,0 +1,42 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.13.35818.85
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AspireReferenceExpressions.AppHost", "AspireReferenceExpressions.AppHost\AspireReferenceExpressions.AppHost.csproj", "{F4DCC7B2-3834-460D-956F-A1280BBB730C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AspireReferenceExpressions.ServiceDefaults", "AspireReferenceExpressions.ServiceDefaults\AspireReferenceExpressions.ServiceDefaults.csproj", "{315B3204-3FAF-951F-2945-654712FAABD1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AspireReferenceExpressions.API", "AspireReferenceExpressions.API\AspireReferenceExpressions.API.csproj", "{EAD0822D-5A68-EBBD-C268-C33EFB8F4116}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AspireReferenceExpressions.Web", "AspireReferenceExpressions.Web\AspireReferenceExpressions.Web.csproj", "{1F900862-3C50-2254-729C-26377166C46F}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F4DCC7B2-3834-460D-956F-A1280BBB730C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F4DCC7B2-3834-460D-956F-A1280BBB730C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F4DCC7B2-3834-460D-956F-A1280BBB730C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F4DCC7B2-3834-460D-956F-A1280BBB730C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{315B3204-3FAF-951F-2945-654712FAABD1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{315B3204-3FAF-951F-2945-654712FAABD1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{315B3204-3FAF-951F-2945-654712FAABD1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{315B3204-3FAF-951F-2945-654712FAABD1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EAD0822D-5A68-EBBD-C268-C33EFB8F4116}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EAD0822D-5A68-EBBD-C268-C33EFB8F4116}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EAD0822D-5A68-EBBD-C268-C33EFB8F4116}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EAD0822D-5A68-EBBD-C268-C33EFB8F4116}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1F900862-3C50-2254-729C-26377166C46F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1F900862-3C50-2254-729C-26377166C46F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1F900862-3C50-2254-729C-26377166C46F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1F900862-3C50-2254-729C-26377166C46F}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {8D77C1BA-3106-4619-947C-C5106FB567DE}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
## Summary

Adds a new section describing how you can use reference expressions to manipulate connection strings in .NET Aspire 9.2 and later.

Fixes #2710
