### PR TITLE
Fixed documentation to use the correct variable name

### DIFF
--- a/docs/database/includes/azure-sql-hosting.md
+++ b/docs/database/includes/azure-sql-hosting.md
@@ -84,7 +84,7 @@ var builder = DistributedApplication.CreateBuilder(args);
 var azureSql = builder.AddAzureSqlServer("azuresql")
                       .RunAsContainer();
 
-var azureSqlData = postgres.AddDatabase("database");
+var azureSqlData = azureSql.AddDatabase("database");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>()
                             .WithReference(azureSqlData);


### PR DESCRIPTION
## Summary

The documentation listed azureSql as the SQLServer variable. But then when the database is referenced it uses postgres as the server that it's adding a database to. This change corrects the documentation so it references azureSql instead.

Fixes #Issue_Number (if available)
