### PR TITLE
Documents the issue with deploying data volumes to ACA.

### DIFF
--- a/docs/database/includes/mysql-app-host.md
+++ b/docs/database/includes/mysql-app-host.md
@@ -84,6 +84,11 @@ The data volume is used to persist the MySQL server data outside the lifecycle o
 > [!WARNING]
 > The password is stored in the data volume. When using a data volume and if the password changes, it will not work until you delete the volume.
 
+> [!IMPORTANT]
+> Some database integrations, including the .NET Aspire MySQL integration, can't successfully use data volumes after deployment to Azure Container Apps (ACA). This is because ACA uses Server Message Block (SMB) to connect containers to data volumes, and some systems can't use this connection. In the Aspire Dashboard, a database affected by this issue has a status of **Activating** or **Activation Failed** but is never listed as **Running**.
+>
+> You can resolve the problem by deploying to a Kubernetes cluster, such as Azure Kubernetes Services (AKS). For more information, see [.NET Aspire deployments](../../deployment/overview.md).
+
 ### Add a MySQL resource with a data bind mount
 
 To add a data bind mount to the MySQL resource, call the <xref:Aspire.Hosting.MySqlBuilderExtensions.WithDataBindMount*> method:

--- a/docs/database/includes/postgresql-app-host.md
+++ b/docs/database/includes/postgresql-app-host.md
@@ -198,6 +198,12 @@ var exampleProject = builder.AddProject<Projects.ExampleProject>()
 
 The data volume is used to persist the PostgreSQL server data outside the lifecycle of its container. The data volume is mounted at the `/var/lib/postgresql/data` path in the PostgreSQL server container and when a `name` parameter isn't provided, the name is generated at random. For more information on data volumes and details on why they're preferred over [bind mounts](#add-postgresql-server-resource-with-data-bind-mount), see [Docker docs: Volumes](https://docs.docker.com/engine/storage/volumes).
 
+> [!IMPORTANT]
+> Some database integrations, including the .NET Aspire PostgreSQL integration, can't successfully use data volumes after deployment to Azure Container Apps (ACA). This is because ACA uses Server Message Block (SMB) to connect containers to data volumes, and some systems can't use this connection. In the Aspire Dashboard, a database affected by this issue has a status of **Activating** or **Activation Failed** but is never listed as **Running**.
+>
+> You can resolve the problem by using the managed service **Azure Database for PostgreSQL** to host the deployed database instead of a container in ACA, which is the recommended approach regardless of this issue. The following App Host code shows how to deploy a database to Azure Database for PostgreSQL, but run it as a container, with a data volume, during development:
+> :::code language="csharp" source="../snippets/postgres-data-volume-deploy/AppHost.cs":::
+
 ### Add PostgreSQL server resource with data bind mount
 
 To add a data bind mount to the PostgreSQL server resource, call the <xref:Aspire.Hosting.PostgresBuilderExtensions.WithDataBindMount*> method:

--- a/docs/database/mongodb-integration.md
+++ b/docs/database/mongodb-integration.md
@@ -98,6 +98,11 @@ The data volume is used to persist the MongoDB server data outside the lifecycle
 > [!WARNING]
 > The password is stored in the data volume. When using a data volume and if the password changes, it will not work until you delete the volume.
 
+> [!IMPORTANT]
+> Some database integrations, including the .NET Aspire MongoDB integration, can't successfully use data volumes after deployment to Azure Container Apps (ACA). This is because ACA uses Server Message Block (SMB) to connect containers to data volumes, and some systems can't use this connection. In the Aspire Dashboard, a database affected by this issue has a status of **Activating** or **Activation Failed** but is never listed as **Running**.
+>
+> You can resolve the problem by deploying to a Kubernetes cluster, such as Azure Kubernetes Services (AKS). For more information, see [.NET Aspire deployments](../deployment/overview.md).
+
 ### Add MongoDB server resource with data bind mount
 
 To add a data bind mount to the MongoDB server resource, call the <xref:Aspire.Hosting.MongoDBBuilderExtensions.WithDataBindMount*> method:

--- a/docs/database/snippets/postgres-data-volume-deploy/.aspire/settings.json
+++ b/docs/database/snippets/postgres-data-volume-deploy/.aspire/settings.json
@@ -1,0 +1,3 @@
+{
+  "appHostPath": "../PostgresDataVolumeDeploy.csproj"
+}

--- a/docs/database/snippets/postgres-data-volume-deploy/AppHost.cs
+++ b/docs/database/snippets/postgres-data-volume-deploy/AppHost.cs
@@ -1,11 +1,9 @@
 var builder = DistributedApplication.CreateBuilder(args);
 
 var postgres = builder.AddAzurePostgresFlexibleServer("postgres")
-                      .RunAsContainer(ConfPostgresContainer);
+                      .RunAsContainer(container => 
+                      {
+                        container.WithDataVolume();
+                      });
 
 builder.Build().Run();
-
-static void ConfPostgresContainer(IResourceBuilder<PostgresServerResource> container)
-{
-    container.WithDataVolume();
-}

--- a/docs/database/snippets/postgres-data-volume-deploy/AppHost.cs
+++ b/docs/database/snippets/postgres-data-volume-deploy/AppHost.cs
@@ -1,0 +1,11 @@
+var builder = DistributedApplication.CreateBuilder(args);
+
+var postgres = builder.AddAzurePostgresFlexibleServer("postgres")
+                      .RunAsContainer(ConfPostgresContainer);
+
+builder.Build().Run();
+
+static void ConfPostgresContainer(IResourceBuilder<PostgresServerResource> container)
+{
+    container.WithDataVolume();
+}

--- a/docs/database/snippets/postgres-data-volume-deploy/PostgresDataVolumeDeploy.csproj
+++ b/docs/database/snippets/postgres-data-volume-deploy/PostgresDataVolumeDeploy.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Sdk Name="Aspire.AppHost.Sdk" Version="9.3.0" />
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <UserSecretsId>c81922d4-3587-4e05-b356-6c23e82a3095</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.3.0" />
+    <PackageReference Include="Aspire.Hosting.Azure.PostgreSQL" Version="9.3.0" />
+  </ItemGroup>
+
+</Project>

--- a/docs/database/snippets/postgres-data-volume-deploy/Properties/launchSettings.json
+++ b/docs/database/snippets/postgres-data-volume-deploy/Properties/launchSettings.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:17122;http://localhost:15166",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21092",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22232"
+      }
+    },
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:15166",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19222",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20011"
+      }
+    }
+  }
+}

--- a/docs/database/snippets/postgres-data-volume-deploy/appsettings.Development.json
+++ b/docs/database/snippets/postgres-data-volume-deploy/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/docs/database/snippets/postgres-data-volume-deploy/appsettings.json
+++ b/docs/database/snippets/postgres-data-volume-deploy/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "Aspire.Hosting.Dcp": "Warning"
+    }
+  }
+}

--- a/docs/database/snippets/postgres-data-volume-deploy/postgres-data-volume-deploy.sln
+++ b/docs/database/snippets/postgres-data-volume-deploy/postgres-data-volume-deploy.sln
@@ -1,0 +1,24 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.2.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PostgresDataVolumeDeploy", "PostgresDataVolumeDeploy.csproj", "{71526FF8-0526-25DB-0EAC-4A361E2DFAA5}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{71526FF8-0526-25DB-0EAC-4A361E2DFAA5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{71526FF8-0526-25DB-0EAC-4A361E2DFAA5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{71526FF8-0526-25DB-0EAC-4A361E2DFAA5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{71526FF8-0526-25DB-0EAC-4A361E2DFAA5}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {5AD02227-BB0F-485F-BC82-994E7A053AC3}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
## Summary

Added notes to the PostgreSQL, MySQL, and MongoDB articles explaining that data volumes are not compatible with deployment to ACA. For PostgreSQL, suggested using Azure Database for PostgreSQL. For the others, deploying to k8s because there's no equivalent integration.

Fixes #3387


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/database/mongodb-integration.md](https://github.com/dotnet/docs-aspire/blob/1e6db04690e52e303e55d11e6820fa98f3792776/docs/database/mongodb-integration.md) | [.NET Aspire MongoDB database integration](https://review.learn.microsoft.com/en-us/dotnet/aspire/database/mongodb-integration?branch=pr-en-us-3706) |


<!-- PREVIEW-TABLE-END -->