### PR TITLE
Fixed typo in Azure Container Registry article

### DIFF
--- a/docs/azure/container-registry-integration.md
+++ b/docs/azure/container-registry-integration.md
@@ -9,7 +9,7 @@ ms.date: 05/09/2025
 [!INCLUDE [includes-hosting](../includes/includes-hosting.md)]
 
 > [!IMPORTANT]
-> The .NET Aspire Azure Functions integration is currently in preview and is subject to change.
+> The .NET Aspire Azure Container Registry integration is currently in preview and is subject to change.
 
 [Azure Container Registry (ACR)](/azure/container-registry) is a managed Docker container registry service that simplifies the storage, management, and deployment of container images. The .NET Aspire integration allows you to provision or reference an existing Azure Container Registry and seamlessly integrate it with your app's compute environments.
 


### PR DESCRIPTION
## Summary

It referred to the Azure Functions integration instead of the Azure Container Registry integration. This PR corrects that.

Fixes #3708


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/azure/container-registry-integration.md](https://github.com/dotnet/docs-aspire/blob/a463c25b5351da92c185ab2ed3cb44e23f0068ce/docs/azure/container-registry-integration.md) | [.NET Aspire Azure Container Registry integration (Preview)](https://review.learn.microsoft.com/en-us/dotnet/aspire/azure/container-registry-integration?branch=pr-en-us-3721) |

<!-- PREVIEW-TABLE-END -->