### PR TITLE
Update container version for standalone dashboard examples

### DIFF
--- a/docs/fundamentals/dashboard/standalone.md
+++ b/docs/fundamentals/dashboard/standalone.md
@@ -25,7 +25,7 @@ docker run --rm -it -d \
     -p 18888:18888 \
     -p 4317:18889 \
     --name aspire-dashboard \
-    mcr.microsoft.com/dotnet/aspire-dashboard:9.0
+    mcr.microsoft.com/dotnet/aspire-dashboard:latest
 ```
 
 ## [PowerShell](#tab/powershell)
@@ -35,7 +35,7 @@ docker run --rm -it -d `
     -p 18888:18888 `
     -p 4317:18889 `
     --name aspire-dashboard `
-    mcr.microsoft.com/dotnet/aspire-dashboard:9.0
+    mcr.microsoft.com/dotnet/aspire-dashboard:latest
 ```
 
 ---


### PR DESCRIPTION
## Summary

Updates the container image version from `:9.0` to `:latest` to avoid docs becoming out of date as new versions are published.

Fixes #3818


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/dashboard/standalone.md](https://github.com/dotnet/docs-aspire/blob/726c69ea4861c840f77abf0cc94d395a9a22fa4c/docs/fundamentals/dashboard/standalone.md) | [Standalone .NET Aspire dashboard](https://review.learn.microsoft.com/en-us/dotnet/aspire/fundamentals/dashboard/standalone?branch=pr-en-us-3819) |

<!-- PREVIEW-TABLE-END -->