### PR TITLE
Add instructions to check for installed templates to the existing app tutorial

### DIFF
--- a/docs/get-started/add-aspire-existing-app.md
+++ b/docs/get-started/add-aspire-existing-app.md
@@ -184,13 +184,13 @@ No matter which tool you use—starting multiple projects manually or configurin
 
 If you've worked with .NET Aspire on your current computer before, you likely have the necessary .NET project templates already installed. You can check by using the following command:
 
-```bash
-dotnet new list ".NET Aspire"
+```dotnetcli
+dotnet new list aspire
 ```
 
 If the .NET Aspire templates are installed, the output resembles:
 
-```bash
+```dotnetcli
 These templates matched your input: '.NET Aspire'
 
 Template Name       Short Name              Language  Tags
@@ -208,7 +208,7 @@ In this tutorial, you'll add a App Host project and a Service Defaults project.
 
 If the previous command didn't find any templates you must install them. Execute this command:
 
-```bash
+```dotnetcli
 dotnet new install Aspire.ProjectTemplates
 ```
 


### PR DESCRIPTION
## Summary

The tutorial [Add .NET Aspire to an existing .NET app](https://learn.microsoft.com/dotnet/aspire/get-started/add-aspire-existing-app) only works if the user has already installed the .NET Aspire templates. They are not listed in the prerequisites. I've added a section describing how to checked whether they are present and, if not, install them.

Fixes #3854


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/get-started/add-aspire-existing-app.md](https://github.com/dotnet/docs-aspire/blob/e97fd1fe4715ec3f0a19a5a5a9517c268841a6bd/docs/get-started/add-aspire-existing-app.md) | [Tutorial: Add .NET Aspire to an existing .NET app](https://review.learn.microsoft.com/en-us/dotnet/aspire/get-started/add-aspire-existing-app?branch=pr-en-us-3923) |


<!-- PREVIEW-TABLE-END -->