### PR TITLE
Adds uv documentation in Python Extensions

### DIFF
--- a/docs/community-toolkit/hosting-python-extensions.md
+++ b/docs/community-toolkit/hosting-python-extensions.md
@@ -79,6 +79,8 @@ builder.Build().Run();
 
 The uv application can be added as a reference to other resources in the AppHost project.
 
+---
+
 ## See also
 
 - [Orchestrate Python apps in .NET Aspire](../get-started/build-aspire-apps-with-Python.md)

--- a/docs/community-toolkit/hosting-python-extensions.md
+++ b/docs/community-toolkit/hosting-python-extensions.md
@@ -63,7 +63,7 @@ The Uvicorn application can be added as a reference to other resources in the Ap
 
 # [uv](#tab/uv)
 
-In the _:::no-loc text="Program.cs":::_ file of your app host project, call the `AddUvApp` method to add a Uvicorn application to the builder.
+In the _:::no-loc text="Program.cs":::_ file of your app host project, call the `AddUvApp` method to add a uv application to the builder.
 
 ```csharp
 var builder = DistributedApplication.CreateBuilder(args);

--- a/docs/community-toolkit/hosting-python-extensions.md
+++ b/docs/community-toolkit/hosting-python-extensions.md
@@ -11,7 +11,7 @@ ms.date: 11/19/2024
 [!INCLUDE [banner](includes/banner.md)]
 
 In this article, you learn about the .NET Aspire Community Toolkit Python hosting extensions package which provides extra functionality to the .NET Aspire [Python hosting package](https://nuget.org/packages/Aspire.Hosting.Python).
-The extensions package lets you run [Uvicorn](https://www.uvicorn.org/) applications.
+The extensions package lets you run [Uvicorn](https://www.uvicorn.org/) and [uv](https://docs.astral.sh/uv/) applications.
 
 ## Hosting integration
 
@@ -36,7 +36,13 @@ For more information, see [dotnet add package](/dotnet/core/tools/dotnet-add-pac
 
 ## Example usage
 
+The following sections detail various usages, from running Uvicorn applications to using specific package managers such as uv.
+
 To work with Python apps, they need to be within a virtual environment. To create a virtual environment, refer to the [Initialize the Python virtual environment](../get-started/build-aspire-apps-with-python.md?tabs=powershell#initialize-the-python-virtual-environment) section.
+
+The `PORT` environment variable is used to determine the port the Uvicorn application should listen on. By default, this port is randomly assigned by .NET Aspire. The name of the environment variable can be changed by passing a different value to the <xref:Aspire.Hosting.ResourceBuilderExtensions.WithHttpEndpoint*> method.
+
+# [Uvicorn](#tab/uvicorn)
 
 In the _:::no-loc text="Program.cs":::_ file of your app host project, call the `AddUvicornApp` method to add a Uvicorn application to the builder.
 
@@ -53,9 +59,18 @@ var uvicorn = builder.AddUvicornApp(
 builder.Build().Run();
 ```
 
-The `PORT` environment variable is used to determine the port the Uvicorn application should listen on. By default, this port is randomly assigned by .NET Aspire. The name of the environment variable can be changed by passing a different value to the <xref:Aspire.Hosting.ResourceBuilderExtensions.WithHttpEndpoint*> method.
-
 The Uvicorn application can be added as a reference to other resources in the AppHost project.
+
+# [uv](#tab/uv)
+
+In the _:::no-loc text="Program.cs":::_ file of your app host project, call the `AddUvApp` method to add a Uvicorn application to the builder.
+
+```csharp
+var uvicorn = builder.AddUvApp("uvapp", "../uv-api", "uv-api")
+    .WithHttpEndpoint(env: "PORT");
+```
+
+The uv application can be added as a reference to other resources in the AppHost project.
 
 ## See also
 

--- a/docs/community-toolkit/hosting-python-extensions.md
+++ b/docs/community-toolkit/hosting-python-extensions.md
@@ -68,7 +68,7 @@ In the _:::no-loc text="Program.cs":::_ file of your app host project, call the 
 ```csharp
 var builder = DistributedApplication.CreateBuilder(args);
 
-var uvicorn = builder.AddUvApp(
+var uv = builder.AddUvApp(
         name: "uvapp", 
         projectDirectory: "../uv-api", 
         scriptPath: "uv-api")

--- a/docs/community-toolkit/hosting-python-extensions.md
+++ b/docs/community-toolkit/hosting-python-extensions.md
@@ -66,8 +66,15 @@ The Uvicorn application can be added as a reference to other resources in the Ap
 In the _:::no-loc text="Program.cs":::_ file of your app host project, call the `AddUvApp` method to add a Uvicorn application to the builder.
 
 ```csharp
-var uvicorn = builder.AddUvApp("uvapp", "../uv-api", "uv-api")
+var builder = DistributedApplication.CreateBuilder(args);
+
+var uvicorn = builder.AddUvApp(
+        name: "uvapp", 
+        projectDirectory: "../uv-api", 
+        scriptPath: "uv-api")
     .WithHttpEndpoint(env: "PORT");
+
+builder.Build().Run();
 ```
 
 The uv application can be added as a reference to other resources in the AppHost project.


### PR DESCRIPTION
## Summary

Added documentation for the uv aspire integration from the [community toolkit](https://github.com/CommunityToolkit/Aspire/tree/main/src/CommunityToolkit.Aspire.Hosting.Python.Extensions).
Documentation has been added to the already existing [Python Extension documentation](https://learn.microsoft.com/en-us/dotnet/aspire/community-toolkit/hosting-python-extensions?tabs=dotnet-cli).

Fixes #2426


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/community-toolkit/hosting-python-extensions.md](https://github.com/dotnet/docs-aspire/blob/1edfbf8645b3cc571a00b9cb1766c844aad29742/docs/community-toolkit/hosting-python-extensions.md) | [Community Toolkit Python hosting extensions](https://review.learn.microsoft.com/en-us/dotnet/aspire/community-toolkit/hosting-python-extensions?branch=pr-en-us-4033) |


<!-- PREVIEW-TABLE-END -->