### PR TITLE
Include template installation instructions in the ".NET Aspire templates" article.

### DIFF
--- a/docs/fundamentals/aspire-sdk-templates.md
+++ b/docs/fundamentals/aspire-sdk-templates.md
@@ -64,6 +64,10 @@ The following .NET Aspire project templates are available:
   > [!IMPORTANT]
   > The service defaults project template takes a `FrameworkReference` dependency on `Microsoft.AspNetCore.App`. This may not be ideal for some project types. For more information, see [.NET Aspire service defaults](service-defaults.md).
 
+## Install the .NET Aspire templates
+
+[!INCLUDE [Install templates](includes/install-templates.md)]
+
 ## Create solutions and projects using templates
 
 To create a .NET Aspire solution or project, use Visual Studio, Visual Studio Code, or the .NET CLI, and base it on the available templates. Explore additional .NET Aspire templates in the [.NET Aspire samples](https://github.com/dotnet/aspire-samples) repository.

--- a/docs/fundamentals/includes/install-templates.md
+++ b/docs/fundamentals/includes/install-templates.md
@@ -1,0 +1,37 @@
+---
+ms.topic: include
+---
+
+:::zone pivot="visual-studio"
+
+To install the .NET Aspire templates in Visual Studio, you need to manually install them unless you're using Visual Studio 17.12 or later. For Visual Studio 17.9 to 17.11, follow these steps:
+
+1. Open Visual Studio.
+1. Go to **Tools** > **NuGet Package Manager** > **Package Manager Console**.
+1. Run the following command to install the templates:
+
+  ```dotnetcli
+  dotnet new install Aspire.ProjectTemplates
+  ```
+
+For Visual Studio 17.12 or later, the .NET Aspire templates are installed automatically.
+
+:::zone-end
+:::zone pivot="vscode,dotnet-cli"
+
+To install these templates, use the [dotnet new install](/dotnet/core/tools/dotnet-new-install) command, passing in the `Aspire.ProjectTemplates` NuGet identifier.
+
+```dotnetcli
+dotnet new install Aspire.ProjectTemplates
+```
+
+To install a specific version, append the version number to the package name:
+
+```dotnetcli
+dotnet new install Aspire.ProjectTemplates::9.3.0
+```
+
+> [!TIP]
+> If you already have the .NET Aspire workload installed, you need to pass the `--force` flag to overwrite the existing templates. Feel free to uninstall the .NET Aspire workload.
+
+:::zone-end

--- a/docs/fundamentals/setup-tooling.md
+++ b/docs/fundamentals/setup-tooling.md
@@ -66,39 +66,7 @@ To install the .NET Aspire workload in Visual Studio 2022, use the Visual Studio
 
 ### Install the .NET Aspire templates
 
-:::zone pivot="visual-studio"
-
-To install the .NET Aspire templates in Visual Studio, you need to manually install them unless you're using Visual Studio 17.12 or later. For Visual Studio 17.9 to 17.11, follow these steps:
-
-1. Open Visual Studio.
-1. Go to **Tools** > **NuGet Package Manager** > **Package Manager Console**.
-1. Run the following command to install the templates:
-
-  ```dotnetcli
-  dotnet new install Aspire.ProjectTemplates
-  ```
-
-For Visual Studio 17.12 or later, the .NET Aspire templates are installed automatically.
-
-:::zone-end
-:::zone pivot="vscode,dotnet-cli"
-
-To install these templates, use the [dotnet new install](/dotnet/core/tools/dotnet-new-install) command, passing in the `Aspire.ProjectTemplates` NuGet identifier.
-
-```dotnetcli
-dotnet new install Aspire.ProjectTemplates
-```
-
-To install a specific version, append the version number to the package name:
-
-```dotnetcli
-dotnet new install Aspire.ProjectTemplates::9.3.0
-```
-
-> [!TIP]
-> If you already have the .NET Aspire workload installed, you need to pass the `--force` flag to overwrite the existing templates. Feel free to uninstall the .NET Aspire workload.
-
-:::zone-end
+[!INCLUDE [Install templates](includes/install-templates.md)]
 
 ### List the .NET Aspire templates
 


### PR DESCRIPTION
## Summary

Moved the template installation instructions into an include file, then linked to that include file from both:

- [.NET Aspire setup and tooling](https://learn.microsoft.com/dotnet/aspire/fundamentals/setup-tooling)
- [.NET Aspire templates](https://learn.microsoft.com/dotnet/aspire/fundamentals/aspire-sdk-templates)

Fixes #3864


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/aspire-sdk-templates.md](https://github.com/dotnet/docs-aspire/blob/8b14a274334fb6051d86d67a46db7d333c9383bc/docs/fundamentals/aspire-sdk-templates.md) | [.NET Aspire templates](https://review.learn.microsoft.com/en-us/dotnet/aspire/fundamentals/aspire-sdk-templates?branch=pr-en-us-4048) |
| [docs/fundamentals/setup-tooling.md](https://github.com/dotnet/docs-aspire/blob/8b14a274334fb6051d86d67a46db7d333c9383bc/docs/fundamentals/setup-tooling.md) | [.NET Aspire tooling](https://review.learn.microsoft.com/en-us/dotnet/aspire/fundamentals/setup-tooling?branch=pr-en-us-4048) |

<!-- PREVIEW-TABLE-END -->