### PR TITLE
Improved the scripts that retrieve the login token from the container logs

### DIFF
--- a/docs/fundamentals/dashboard/standalone.md
+++ b/docs/fundamentals/dashboard/standalone.md
@@ -62,13 +62,23 @@ Alternatively, you can obtain the token from the logs by using the `docker` comm
 ## [Bash](#tab/bash)
 
 ```bash
-docker container logs aspire-dashboard | grep "t="
+#!/bin/bash
+loginLine=$(docker container logs aspire-dashboard | grep "login?t=")
+match=$(echo "$loginLine" | sed -n 's/.*login?t=\([^[:space:]]*\).*/\1/p')
+echo -n "$match" | xclip -selection clipboard
+echo "$match"
 ```
+
+> [!NOTE]
+> This script requires that your system has the `sed` and `xclip` tools installed.
 
 ## [PowerShell](#tab/powershell)
 
 ```powershell
-docker container logs aspire-dashboard | sls "t="
+$loginLine =  docker container logs aspire-dashboard | Select-String "login\?t="
+$matches = [regex]::Match($loginLine, "(?<=login\?t=)(\S+)")
+$matches.Value | Set-Clipboard
+echo $matches.Value
 ```
 
 ---


### PR DESCRIPTION
## Summary

- Replaced the alias `sls` with the PowerShell cmdlet "Select-String"
- Returned just the token instead of the whole line from the container log.
- Copied the token to the clipboard to save the users a step.

Fixes #4134


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/dashboard/standalone.md](https://github.com/dotnet/docs-aspire/blob/8c73309760b724eb56252e21bc6f4ae2a69c4a95/docs/fundamentals/dashboard/standalone.md) | [Standalone .NET Aspire dashboard](https://review.learn.microsoft.com/en-us/dotnet/aspire/fundamentals/dashboard/standalone?branch=pr-en-us-4135) |

<!-- PREVIEW-TABLE-END -->