### PR TITLE
Propagate important note about aspire exec feature flag to CLI overview

### DIFF
--- a/docs/cli/includes/exec-feature-flag-note.md
+++ b/docs/cli/includes/exec-feature-flag-note.md
@@ -1,0 +1,6 @@
+---
+ms.topic: include
+---
+
+> [!IMPORTANT]
+> 🧪 **Feature Flag**: The `aspire exec` command is behind a feature flag and **disabled by default** in this release. It must be explicitly enabled for use with `aspire config set features.execCommandEnabled true`.

--- a/docs/cli/overview.md
+++ b/docs/cli/overview.md
@@ -90,3 +90,5 @@ The `aspire config` command lets you manage Aspire CLI configuration settings. U
 [_Command reference: `aspire exec`_](../cli-reference/aspire-exec.md)
 
 The `aspire exec` command runs a command in the context of a specific Aspire resource, inheriting that resource's configuration, including environment variables, connection strings, and working directory. This is particularly useful for scenarios like running Entity Framework migrations where you need to run commands with the same configuration as your application. For example, you can run `aspire exec --resource api -- dotnet ef migrations add Init` to run Entity Framework commands with the proper database connection strings automatically configured.
+
+[!INCLUDE [aspire exec feature flag note](includes/exec-feature-flag-note.md)]

--- a/docs/whats-new/dotnet-aspire-9.4.md
+++ b/docs/whats-new/dotnet-aspire-9.4.md
@@ -100,8 +100,7 @@ aspire exec --start-resource my-worker -- npm run build
 - **Resource targeting** with `--resource` or `--start-resource` options
 - **Command execution** in the context of your Aspirified application
 
-> [!IMPORTANT]
-> 🧪 **Feature Flag**: The `aspire exec` command is behind a feature flag and **disabled by default** in this release. It must be explicitly enabled for use with `aspire config set features.execCommandEnabled true`.
+[!INCLUDE [aspire exec feature flag note](../cli/includes/exec-feature-flag-note.md)]
 
 #### `aspire deploy`
 


### PR DESCRIPTION
## Summary

Moves the Important note into an include file and then includes that in both the What New article and the Aspire CLI Overview article.

Fixes #4168
