### PR TITLE
Correct links to point to 9.4 bits

### DIFF
--- a/docs/index.yml
+++ b/docs/index.yml
@@ -360,7 +360,7 @@ additionalContent:
     items:
     - title: ".NET Aspire API reference"
       summary: API reference documentation for .NET Aspire
-      url: /dotnet/api?view=dotnet-aspire-9.3&preserve-view=true
+      url: /dotnet/api?view=dotnet-aspire-9.4&preserve-view=true
     - title: ".NET API reference"
       summary: API reference documentation for .NET
       url: /dotnet/api?view=net-9.0&preserve-view=true

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -284,9 +284,9 @@ items:
       displayName: web pubsub,real-time,messaging
       href: messaging/azure-web-pubsub-integration.md
     - name: Aspire.Hosting.Azure API reference
-      href: /dotnet/api/?term=Aspire.Hosting.Azure&view=dotnet-aspire-9.3&preserve-view=true
+      href: /dotnet/api/?term=Aspire.Hosting.Azure&view=dotnet-aspire-9.4&preserve-view=true
     - name: Aspire.Azure API reference
-      href: /dotnet/api/?term=Aspire.Azure&view=dotnet-aspire-9.3&preserve-view=true
+      href: /dotnet/api/?term=Aspire.Azure&view=dotnet-aspire-9.4&preserve-view=true
   - name: Elasticsearch
     displayName: elasticsearch,search
     href: search/elasticsearch-integration.md
@@ -435,7 +435,7 @@ items:
     - name: RavenDB
       href: community-toolkit/ravendb.md
   - name: Aspire.Hosting API reference
-    href: /dotnet/api/?term=Aspire.Hosting&view=dotnet-aspire-9.3&preserve-view=true
+    href: /dotnet/api/?term=Aspire.Hosting&view=dotnet-aspire-9.4&preserve-view=true
 
 - name: Custom integrations
   items:
@@ -583,7 +583,7 @@ items:
         - name: Publishing to Azure APIs are experimental
           href: diagnostics/aspireazure001.md
   - name: .NET Aspire API reference
-    href: /dotnet/api?view=dotnet-aspire-9.3&preserve-view=true
+    href: /dotnet/api?view=dotnet-aspire-9.4&preserve-view=true
   - name: .NET Aspire FAQ
     displayName: iis,functions,deploy,azure,kubernetes
     href: reference/aspire-faq.yml

--- a/docs/whats-new/index.yml
+++ b/docs/whats-new/index.yml
@@ -32,6 +32,10 @@ landingContent:
   linkLists:
   - linkListType: whats-new
     links:
+    - text: .NET Aspire 9.4
+      url: https://github.com/dotnet/aspire/releases/tag/v9.4.0
+    - text: .NET Aspire 9.3
+      url: https://github.com/dotnet/aspire/releases/tag/v9.3.0
     - text: .NET Aspire 9.2
       url: https://github.com/dotnet/aspire/releases/tag/v9.2.0
     - text: .NET Aspire 9.1
@@ -46,10 +50,8 @@ landingContent:
       url: https://github.com/dotnet/aspire/releases/tag/v8.2.0
     - text: .NET Aspire 8.1.0
       url: https://github.com/dotnet/aspire/releases/tag/v8.1.0
-    - text: .NET Aspire 8.0.2
-      url: https://github.com/dotnet/aspire/releases/tag/v8.0.2
-    - text: .NET Aspire 8.0.0
-      url: https://github.com/dotnet/aspire/releases/tag/v8.0.0
+    - text: Older releases
+      url: https://github.com/dotnet/aspire/releases
 - title: Latest documentation updates
   linkLists:
   - linkListType: whats-new

--- a/docs/whats-new/toc.yml
+++ b/docs/whats-new/toc.yml
@@ -26,6 +26,10 @@ items:
   href: ../compatibility/breaking-changes.md
 - name: GitHub releases
   items:
+  - name: .NET Aspire 9.4
+    href: https://github.com/dotnet/aspire/releases/tag/v9.4.0
+  - name: .NET Aspire 9.3
+    href: https://github.com/dotnet/aspire/releases/tag/v9.3.0
   - name: .NET Aspire 9.2
     href: https://github.com/dotnet/aspire/releases/tag/v9.2.0
   - name: .NET Aspire 9.1
@@ -38,10 +42,8 @@ items:
     href: https://github.com/dotnet/aspire/releases/tag/v8.2.0
   - name: .NET Aspire 8.1.0
     href: https://github.com/dotnet/aspire/releases/tag/v8.1.0
-  - name: .NET Aspire 8.0.2
-    href: https://github.com/dotnet/aspire/releases/tag/v8.0.2
-  - name: .NET Aspire 8.0.0
-    href: https://github.com/dotnet/aspire/releases/tag/v8.0.0
+  - name: Older releases
+    href: https://github.com/dotnet/aspire/releases
 - name: Latest documentation updates
   expanded: true
   items:


### PR DESCRIPTION
Update API reference links to version 9.4 and add release notes for .NET Aspire 9.4

Fixes #4177

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/index.yml](https://github.com/dotnet/docs-aspire/blob/34df3411ad362297e5ce89e8c9f816fe2f30b98c/docs/index.yml) | [Limit summary to 400 characters](https://review.learn.microsoft.com/en-us/dotnet/aspire/index?branch=pr-en-us-4176) |
| [docs/toc.yml](https://github.com/dotnet/docs-aspire/blob/34df3411ad362297e5ce89e8c9f816fe2f30b98c/docs/toc.yml) | [docs/toc](https://review.learn.microsoft.com/en-us/dotnet/aspire/toc?branch=pr-en-us-4176) |
| [docs/whats-new/index.yml](https://github.com/dotnet/docs-aspire/blob/34df3411ad362297e5ce89e8c9f816fe2f30b98c/docs/whats-new/index.yml) | [.NET Aspire — what's new?](https://review.learn.microsoft.com/en-us/dotnet/aspire/whats-new/index?branch=pr-en-us-4176) |
| [docs/whats-new/toc.yml](https://github.com/dotnet/docs-aspire/blob/34df3411ad362297e5ce89e8c9f816fe2f30b98c/docs/whats-new/toc.yml) | [docs/whats-new/toc](https://review.learn.microsoft.com/en-us/dotnet/aspire/whats-new/toc?branch=pr-en-us-4176) |

<!-- PREVIEW-TABLE-END -->