### PR TITLE
Add section about using InfrastructureResolver classes to the Customize Azure resources article

### DIFF
--- a/docs/azure/customize-azure-resources.md
+++ b/docs/azure/customize-azure-resources.md
@@ -89,6 +89,18 @@ Consider the resulting Bicep file:
 
 The Bicep file reflects the desired configuration of the Azure Container Registry, as defined by the `AddAzureInfrastructure` API.
 
+### Use an infrastructure resolver to customize Azure provisioning options
+
+Another method you can use to customize Azure provisioning is to create an <xref:Azure.Provisioning.Primitives.InfrastructureResolver> and write code in it to implement your requirements. Then add that class to the configuration options for your AppHost.
+
+The custom infrastructure resolver is a class that inherits from `InfrastructureResolver` and overrides the `ResolveResources` method to make the customizations you need. In this example, the name of a Cosmos DB resource is set:
+
+:::code language="csharp" source="snippets/customize-azure-with-infrastructure-resolver/AppHost.cs" id="infrastructure-resolver":::
+
+Having created that class, add it to the configuration options using code like this in the AppHost:
+
+:::code language="csharp" source="snippets/customize-azure-with-infrastructure-resolver/AppHost.cs" id="configure-azure-options":::
+
 ## Use custom Bicep templates
 
 When you're targeting Azure as your desired cloud provider, you can use Bicep to define your infrastructure as code. It aims to drastically simplify the authoring experience with a cleaner syntax and better support for modularity and code reuse.

--- a/docs/azure/snippets/customize-azure-with-infrastructure-resolver/AppHost.cs
+++ b/docs/azure/snippets/customize-azure-with-infrastructure-resolver/AppHost.cs
@@ -1,0 +1,31 @@
+using Aspire.Hosting.Azure;
+using Azure.Provisioning;
+using Azure.Provisioning.Primitives;
+using Azure.Provisioning.CosmosDB;
+using Microsoft.Extensions.DependencyInjection;
+
+// <configure-azure-options>
+var builder = DistributedApplication.CreateBuilder(args);
+
+builder.Services.Configure<AzureProvisioningOptions>(options =>
+{
+    options.ProvisioningBuildOptions.InfrastructureResolvers.Insert(0, new FixedNameInfrastructureResolver());
+});
+
+builder.Build().Run();
+// </configure-azure-options>
+
+// <infrastructure-resolver>
+internal sealed class FixedNameInfrastructureResolver : InfrastructureResolver
+{
+    public override void ResolveProperties(ProvisionableConstruct construct, ProvisioningBuildOptions options)
+    {
+        if (construct is CosmosDBAccount account)
+        {
+            account.Name = "ContosoCosmosDb";
+        }
+
+        base.ResolveProperties(construct, options);
+    }
+}
+// </infrastructure-resolver>

--- a/docs/azure/snippets/customize-azure-with-infrastructure-resolver/AppHost.cs~
+++ b/docs/azure/snippets/customize-azure-with-infrastructure-resolver/AppHost.cs~
@@ -1,0 +1,27 @@
+using Aspire.Hosting.Azure;
+using Azure.Provisioning;
+using Azure.Provisioning.Primitives;
+using Azure.Provisioning.CosmosDB;
+using Microsoft.Extensions.DependencyInjection;
+
+var builder = DistributedApplication.CreateBuilder(args);
+
+builder.Services.Configure<AzureProvisioningOptions>(options =>
+{
+    options.ProvisioningBuildOptions.InfrastructureResolvers.Insert(0, new FixedNameInfrastructureResolver());
+});
+
+builder.Build().Run();
+
+internal sealed class FixedNameInfrastructureResolver : InfrastructureResolver
+{
+    public override void ResolveProperties(ProvisionableConstruct construct, ProvisioningBuildOptions options)
+    {
+        if (construct is CosmosDBAccount account)
+        {
+            account.Name = "ContosoCosmosDb";
+        }
+
+        base.ResolveProperties(construct, options);
+    }
+}

--- a/docs/azure/snippets/customize-azure-with-infrastructure-resolver/CustomizeAzureWithInfrastructureResolver.csproj
+++ b/docs/azure/snippets/customize-azure-with-infrastructure-resolver/CustomizeAzureWithInfrastructureResolver.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Sdk Name="Aspire.AppHost.Sdk" Version="9.4.0" />
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <UserSecretsId>0f6d6204-f9d8-4ca7-bae5-dccb1b132bbf</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.4.0" />
+    <PackageReference Include="Azure.Provisioning" Version="1.3.0" />
+    <PackageReference Include="Aspire.Hosting.Azure.CosmosDB" Version="9.4.0" />
+  </ItemGroup>
+
+</Project>

--- a/docs/azure/snippets/customize-azure-with-infrastructure-resolver/Properties/launchSettings.json
+++ b/docs/azure/snippets/customize-azure-with-infrastructure-resolver/Properties/launchSettings.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:17032;http://localhost:15110",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21110",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22097"
+      }
+    },
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:15110",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19243",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20044"
+      }
+    }
+  }
+}

--- a/docs/azure/snippets/customize-azure-with-infrastructure-resolver/appsettings.Development.json
+++ b/docs/azure/snippets/customize-azure-with-infrastructure-resolver/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/docs/azure/snippets/customize-azure-with-infrastructure-resolver/appsettings.json
+++ b/docs/azure/snippets/customize-azure-with-infrastructure-resolver/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "Aspire.Hosting.Dcp": "Warning"
+    }
+  }
+}

--- a/docs/azure/snippets/customize-azure-with-infrastructure-resolver/customize-azure-with-infrastructure-resolver.sln
+++ b/docs/azure/snippets/customize-azure-with-infrastructure-resolver/customize-azure-with-infrastructure-resolver.sln
@@ -1,0 +1,24 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.2.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CustomizeAzureWithInfrastructureResolver", "CustomizeAzureWithInfrastructureResolver.csproj", "{F6E1845D-4EE9-780B-E79F-F87BD599761D}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F6E1845D-4EE9-780B-E79F-F87BD599761D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F6E1845D-4EE9-780B-E79F-F87BD599761D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F6E1845D-4EE9-780B-E79F-F87BD599761D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F6E1845D-4EE9-780B-E79F-F87BD599761D}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {83D94A4D-6BB3-4B50-A1F7-C86F42B676DE}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
## Summary

Added a section to the [Customize Azure resources](https://learn.microsoft.com/en-us/dotnet/aspire/azure/customize-azure-resources) article describing how to use an overridden InfrastructureResolver class to alter the Bicep generated for Azure resources. Includes snippets.

Fixes #3857
