### PR TITLE
Update API reference URLs to use .NET Aspire 9.0 version

### DIFF
--- a/docs/index.yml
+++ b/docs/index.yml
@@ -360,7 +360,7 @@ additionalContent:
     items:
     - title: ".NET Aspire API reference"
       summary: API reference documentation for .NET Aspire
-      url: /dotnet/api?view=dotnet-aspire-9.4&preserve-view=true
+      url: /dotnet/api?view=dotnet-aspire-9.0&preserve-view=true
     - title: ".NET API reference"
       summary: API reference documentation for .NET
       url: /dotnet/api?view=net-9.0&preserve-view=true

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -284,9 +284,9 @@ items:
       displayName: web pubsub,real-time,messaging
       href: messaging/azure-web-pubsub-integration.md
     - name: Aspire.Hosting.Azure API reference
-      href: /dotnet/api/?term=Aspire.Hosting.Azure&view=dotnet-aspire-9.4&preserve-view=true
+      href: /dotnet/api/?term=Aspire.Hosting.Azure&view=dotnet-aspire-9.0&preserve-view=true
     - name: Aspire.Azure API reference
-      href: /dotnet/api/?term=Aspire.Azure&view=dotnet-aspire-9.4&preserve-view=true
+      href: /dotnet/api/?term=Aspire.Azure&view=dotnet-aspire-9.0&preserve-view=true
   - name: Elasticsearch
     displayName: elasticsearch,search
     href: search/elasticsearch-integration.md
@@ -435,7 +435,7 @@ items:
     - name: RavenDB
       href: community-toolkit/ravendb.md
   - name: Aspire.Hosting API reference
-    href: /dotnet/api/?term=Aspire.Hosting&view=dotnet-aspire-9.4&preserve-view=true
+    href: /dotnet/api/?term=Aspire.Hosting&view=dotnet-aspire-9.0&preserve-view=true
 
 - name: Custom integrations
   items:
@@ -586,7 +586,7 @@ items:
         - name: Publishing to Azure APIs are experimental
           href: diagnostics/aspireazure001.md
   - name: .NET Aspire API reference
-    href: /dotnet/api?view=dotnet-aspire-9.4&preserve-view=true
+    href: /dotnet/api?view=dotnet-aspire-9.0&preserve-view=true
   - name: .NET Aspire FAQ
     displayName: iis,functions,deploy,azure,kubernetes
     href: reference/aspire-faq.yml


### PR DESCRIPTION
## Summary

Fixes #4232


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/index.yml](https://github.com/dotnet/docs-aspire/blob/a3f43e01719b491498e0ec7e85912c79f5f74cb9/docs/index.yml) | [.NET Aspire documentation](https://review.learn.microsoft.com/en-us/dotnet/aspire/index?branch=pr-en-us-4233) |
| [docs/toc.yml](https://github.com/dotnet/docs-aspire/blob/a3f43e01719b491498e0ec7e85912c79f5f74cb9/docs/toc.yml) | [docs/toc](https://review.learn.microsoft.com/en-us/dotnet/aspire/toc?branch=pr-en-us-4233) |

<!-- PREVIEW-TABLE-END -->