### PR TITLE
Fix include files in Storage Integration articles

### DIFF
--- a/docs/storage/includes/storage-app-host.md
+++ b/docs/storage/includes/storage-app-host.md
@@ -53,8 +53,6 @@ When you add an `AzureStorageResource` to the AppHost, it exposes other useful A
 > [!IMPORTANT]
 > When you call <xref:Aspire.Hosting.AzureStorageExtensions.AddAzureStorage*>, it implicitly calls <xref:Aspire.Hosting.AzureProvisionerExtensions.AddAzureProvisioning*>—which adds support for generating Azure resources dynamically during app startup. The app must configure the appropriate subscription and location. For more information, see [Local provisioning: Configuration](../../azure/local-provisioning.md#configuration).
 
-[!INCLUDE [storage-bicep](storage-bicep.md)]
-
 ### Connect to an existing Azure Storage account
 
 You might have an existing Azure Storage account that you want to connect to. You can chain a call to annotate that your <xref:Aspire.Hosting.Azure.AzureStorageResource> is an existing resource:


### PR DESCRIPTION
## Summary

The include file **storage-bicep.md** was referenced in both parent articles and in **storage-app-host.md** causing a long section of content to be repeated in all three Storage Integration articles. I've removed the reference to it from **storage-app-host.md**. 

Fixes #4236
