### PR TITLE
Clarify the difference between InfrastructureResolver and ConfigureInfrastructure to customize Azure resources

### DIFF
--- a/docs/azure/customize-azure-resources.md
+++ b/docs/azure/customize-azure-resources.md
@@ -101,6 +101,9 @@ Having created that class, add it to the configuration options using code like t
 
 :::code language="csharp" source="snippets/customize-azure-with-infrastructure-resolver/AppHost.cs" id="configureazureoptions":::
 
+> [!TIP]
+> Both `InfrastructureResolver` and the `ConfigureInfrastructure` method enable you to customize Azure resources in your AppHost code. The advantage of `InfrastructureResolver` is that you can use it to customize many Azure resources, not just one.
+
 ## Use custom Bicep templates
 
 When you're targeting Azure as your desired cloud provider, you can use Bicep to define your infrastructure as code. It aims to drastically simplify the authoring experience with a cleaner syntax and better support for modularity and code reuse.


### PR DESCRIPTION
## Summary

Added a tip explaining that InfrastructureResolver can customize many Azure resources simultaneously. This contrasts with the ConfigureInfrastructure method, which only applies to a single resource. This change helps developers choose the right customization method.

Fixes #4287


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/azure/customize-azure-resources.md](https://github.com/dotnet/docs-aspire/blob/61c0a15b8cdbf832dc18903429d9da6db3188a19/docs/azure/customize-azure-resources.md) | [Customize Azure resources](https://review.learn.microsoft.com/en-us/dotnet/aspire/azure/customize-azure-resources?branch=pr-en-us-4288) |

<!-- PREVIEW-TABLE-END -->