### PR TITLE
Add warning format to note about unsecured transport setting

### DIFF
--- a/docs/troubleshooting/allow-unsecure-transport.md
+++ b/docs/troubleshooting/allow-unsecure-transport.md
@@ -6,7 +6,7 @@ ms.date: 04/15/2025
 
 # Allow unsecure transport in .NET Aspire
 
-Starting with .NET Aspire preview 5, the AppHost will crash if an `applicationUrl` is configured with an unsecure transport (non-TLS `http`) protocol.
+The AppHost will crash if an `applicationUrl` is configured with an unsecure transport (non-TLS `http`) protocol.
 
 > [!WARNING]
 > This is a security feature to prevent accidental exposure of sensitive data. However, there are scenarios where you might need to allow unsecure transport.

--- a/docs/troubleshooting/allow-unsecure-transport.md
+++ b/docs/troubleshooting/allow-unsecure-transport.md
@@ -6,7 +6,12 @@ ms.date: 04/15/2025
 
 # Allow unsecure transport in .NET Aspire
 
-Starting with .NET Aspire preview 5, the AppHost will crash if an `applicationUrl` is configured with an unsecure transport (non-TLS `http`) protocol. This is a security feature to prevent accidental exposure of sensitive data. However, there are scenarios where you might need to allow unsecure transport. This article explains how to allow unsecure transport in .NET Aspire projects.
+Starting with .NET Aspire preview 5, the AppHost will crash if an `applicationUrl` is configured with an unsecure transport (non-TLS `http`) protocol. 
+
+> [!WARNING]
+> This is a security feature to prevent accidental exposure of sensitive data. However, there are scenarios where you might need to allow unsecure transport.
+
+This article explains how to allow unsecure transport in .NET Aspire projects.
 
 ## Symptoms
 

--- a/docs/troubleshooting/allow-unsecure-transport.md
+++ b/docs/troubleshooting/allow-unsecure-transport.md
@@ -6,7 +6,7 @@ ms.date: 04/15/2025
 
 # Allow unsecure transport in .NET Aspire
 
-Starting with .NET Aspire preview 5, the AppHost will crash if an `applicationUrl` is configured with an unsecure transport (non-TLS `http`) protocol. 
+Starting with .NET Aspire preview 5, the AppHost will crash if an `applicationUrl` is configured with an unsecure transport (non-TLS `http`) protocol.
 
 > [!WARNING]
 > This is a security feature to prevent accidental exposure of sensitive data. However, there are scenarios where you might need to allow unsecure transport.


### PR DESCRIPTION
Make the note about this being a security feature stand out.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/troubleshooting/allow-unsecure-transport.md](https://github.com/dotnet/docs-aspire/blob/1ad85f1c6d40cb577fd537c150892ed53992e061/docs/troubleshooting/allow-unsecure-transport.md) | [Allow unsecure transport in .NET Aspire](https://review.learn.microsoft.com/en-us/dotnet/aspire/troubleshooting/allow-unsecure-transport?branch=pr-en-us-4350) |


<!-- PREVIEW-TABLE-END -->