### PR TITLE
Add a new section on working with existing Kafka cluters.

### DIFF
--- a/docs/messaging/kafka-integration.md
+++ b/docs/messaging/kafka-integration.md
@@ -139,7 +139,7 @@ The hosting integration relies on the [📦 AspNetCore.HealthChecks.Kafka](https
 
 ### Work with larger Kafka clusters
 
-The Aspire Kafka integration deploys a container from the [confluentinc/confluent-local image](https://hub.docker.com/r/confluentinc/confluent-local) to your local container host. This image provides a simple Apache Kafka cluster that runs in [KRaft mode](https://developer.confluent.io/learn/kraft/) and requires no further configuration. It's ideal for developing and testing producers and consumers. However, this image is for local experimentation only and isn't supported by Confluent. It isn't recommended for production environments and you may require a more robust Kafka cluster for testing and staging.
+The Aspire Kafka integration deploys a container from the [confluentinc/confluent-local image](https://hub.docker.com/r/confluentinc/confluent-local) to your local container host. This image provides a simple Apache Kafka cluster that runs in [KRaft mode](https://developer.confluent.io/learn/kraft/) and requires no further configuration. It's ideal for developing and testing producers and consumers. However, this image is for local experimentation only and isn't supported by Confluent. It isn't recommended for production environments and you may require a more robust Kafka cluster for testing and staging. For example, you may require more that one message broker in your cluster.
 
 See the [Kafka documentation](https://kafka.apache.org/documentation/) for details of Kafka cluster setup. Once your engineers have created and configured Kafka, you only need to provide it's location to Aspire by using a connection string.
 
@@ -151,15 +151,13 @@ var kafka = builder.ExecutionContext.IsRunMode
     : builder.AddConnectionString("kafka");
 ```
 
-Make sure you have added the right connection string to the AppHost's **appsettings.json** file:
+The AppHost resolves the connection string from the `ConnectionStrings__kafka` configuration key. It's possible to set this key by adding the connection string to the AppHost's **appsettings.json** file but this method stores the connection string in plain text and  doesn't protect it. Instead, you can use an environment variable or a user secret to store the connection string:
 
-```json
-{
-  "ConnectionStrings": {
-    "kafka": "kafka-broker-1.contoso.com:9092,kafka-broker-2.contoso.com:9092,kafka-broker-3.contoso.com:9092"
-  }
-}
+```cmd
+dotnet user-secrets set "ConnectionStrings:kafka" "kafka-broker-1.contoso.com:9092,kafka-broker-2.contoso.com:9092,kafka-broker-3.contoso.com:9092"
 ```
+
+For more information about protecting app secrets, see [Safe storage of app secrets in development in ASP.NET Core](/aspnet/core/security/app-secrets)
 
 ## Client integration
 

--- a/docs/messaging/kafka-integration.md
+++ b/docs/messaging/kafka-integration.md
@@ -151,13 +151,17 @@ var kafka = builder.ExecutionContext.IsRunMode
     : builder.AddConnectionString("kafka");
 ```
 
+> [!NOTE]
+> For more information about connection strings in Aspire, see [Add existing Azure resources with connection strings](/aspire/azure/integrations-overview#add-existing-azure-resources-with-connection-strings)
+
 The AppHost resolves the connection string from the `ConnectionStrings__kafka` configuration key. It's possible to set this key by adding the connection string to the AppHost's **appsettings.json** file but this method stores the connection string in plain text and  doesn't protect it. Instead, you can use an environment variable or a user secret to store the connection string:
 
 ```cmd
 dotnet user-secrets set "ConnectionStrings:kafka" "kafka-broker-1.contoso.com:9092,kafka-broker-2.contoso.com:9092,kafka-broker-3.contoso.com:9092"
 ```
 
-For more information about protecting app secrets, see [Safe storage of app secrets in development in ASP.NET Core](/aspnet/core/security/app-secrets)
+> [!NOTE]
+> For more information about protecting app secrets, see [Safe storage of app secrets in development in ASP.NET Core](/aspnet/core/security/app-secrets)
 
 ## Client integration
 

--- a/docs/messaging/kafka-integration.md
+++ b/docs/messaging/kafka-integration.md
@@ -152,7 +152,7 @@ var kafka = builder.ExecutionContext.IsRunMode
 ```
 
 > [!NOTE]
-> For more information about connection strings in Aspire, see [Add existing Azure resources with connection strings](../azure/integrations-overview#add-existing-azure-resources-with-connection-strings)
+> For more information about connection strings in Aspire, see [Add existing Azure resources with connection strings](../azure/integrations-overview.md#add-existing-azure-resources-with-connection-strings)
 
 The AppHost resolves the connection string from the `ConnectionStrings__kafka` configuration key. It's possible to set this key by adding the connection string to the AppHost's **appsettings.json** file but this method stores the connection string in plain text and  doesn't protect it. Instead, you can use an environment variable or a user secret to store the connection string:
 

--- a/docs/messaging/kafka-integration.md
+++ b/docs/messaging/kafka-integration.md
@@ -139,7 +139,7 @@ The hosting integration relies on the [📦 AspNetCore.HealthChecks.Kafka](https
 
 ### Working with larger Kafka clusters
 
-The Aspire Kafka integration deploys a container from the [confluentinc/confluent-local image](https://hub.docker.com/r/confluentinc/confluent-local] to your local container host. This image provides a simple Apache Kafka cluster that runs in [KRaft mode](https://developer.confluent.io/learn/kraft/) and requires no further configuration. It's ideal for developing and testing producers and consumers. However, this image is for local experimentation only and isn't supported by Confluent. It isn't recommended for production environments and you may require a more robust Kafka cluster for testing and staging.
+The Aspire Kafka integration deploys a container from the [confluentinc/confluent-local image](https://hub.docker.com/r/confluentinc/confluent-local) to your local container host. This image provides a simple Apache Kafka cluster that runs in [KRaft mode](https://developer.confluent.io/learn/kraft/) and requires no further configuration. It's ideal for developing and testing producers and consumers. However, this image is for local experimentation only and isn't supported by Confluent. It isn't recommended for production environments and you may require a more robust Kafka cluster for testing and staging.
 
 See the [Kafka documentation](https://kafka.apache.org/documentation/) for details of Kafka cluster setup. Once your engineers have created and configured Kafka, you only need to provide it's location to Aspire by using a connection string.
 

--- a/docs/messaging/kafka-integration.md
+++ b/docs/messaging/kafka-integration.md
@@ -137,7 +137,7 @@ The Kafka hosting integration automatically adds a health check for the Kafka se
 
 The hosting integration relies on the [📦 AspNetCore.HealthChecks.Kafka](https://www.nuget.org/packages/AspNetCore.HealthChecks.Kafka) NuGet package.
 
-### Working with larger Kafka clusters
+### Work with larger Kafka clusters
 
 The Aspire Kafka integration deploys a container from the [confluentinc/confluent-local image](https://hub.docker.com/r/confluentinc/confluent-local) to your local container host. This image provides a simple Apache Kafka cluster that runs in [KRaft mode](https://developer.confluent.io/learn/kraft/) and requires no further configuration. It's ideal for developing and testing producers and consumers. However, this image is for local experimentation only and isn't supported by Confluent. It isn't recommended for production environments and you may require a more robust Kafka cluster for testing and staging.
 
@@ -151,7 +151,7 @@ var kafka = builder.ExecutionContext.IsRunMode
     : builder.AddConnectionString("kafka");
 ```
 
-Make sure you have added the right connection string to the **appsettings.json** file:
+Make sure you have added the right connection string to the AppHost's **appsettings.json** file:
 
 ```json
 {

--- a/docs/messaging/kafka-integration.md
+++ b/docs/messaging/kafka-integration.md
@@ -137,6 +137,30 @@ The Kafka hosting integration automatically adds a health check for the Kafka se
 
 The hosting integration relies on the [📦 AspNetCore.HealthChecks.Kafka](https://www.nuget.org/packages/AspNetCore.HealthChecks.Kafka) NuGet package.
 
+### Working with larger Kafka clusters
+
+The Aspire Kafka integration deploys a container from the [confluentinc/confluent-local image](https://hub.docker.com/r/confluentinc/confluent-local] to your local container host. This image provides a simple Apache Kafka cluster that runs in [KRaft mode](https://developer.confluent.io/learn/kraft/) and requires no further configuration. It's ideal for developing and testing producers and consumers. However, this image is for local experimentation only and isn't supported by Confluent. It isn't recommended for production environments and you may require a more robust Kafka cluster for testing and staging.
+
+See the [Kafka documentation](https://kafka.apache.org/documentation/) for details of Kafka cluster setup. Once your engineers have created and configured Kafka, you only need to provide it's location to Aspire by using a connection string.
+
+In the following AppHost code, a local container is used in run mode. At other times, a connection string provides URLs and port numbers for the Kafka brokers:
+
+```csharp
+var kafka = builder.ExecutionContext.IsRunMode
+    ? builder.AddKafka("kafka").WithKafkaUI()
+    : builder.AddConnectionString("kafka");
+```
+
+Make sure you have added the right connection string to the **appsettings.json** file:
+
+```json
+{
+  "ConnectionStrings": {
+    "kafka": "kafka-broker-1.contoso.com:9092,kafka-broker-2.contoso.com:9092,kafka-broker-3.contoso.com:9092"
+  }
+}
+```
+
 ## Client integration
 
 To get started with the .NET Aspire Apache Kafka integration, install the [📦 Aspire.Confluent.Kafka](https://www.nuget.org/packages/Aspire.Confluent.Kafka) NuGet package in the client-consuming project, that is, the project for the application that uses the Apache Kafka client.

--- a/docs/messaging/kafka-integration.md
+++ b/docs/messaging/kafka-integration.md
@@ -152,7 +152,7 @@ var kafka = builder.ExecutionContext.IsRunMode
 ```
 
 > [!NOTE]
-> For more information about connection strings in Aspire, see [Add existing Azure resources with connection strings](/aspire/azure/integrations-overview#add-existing-azure-resources-with-connection-strings)
+> For more information about connection strings in Aspire, see [Add existing Azure resources with connection strings](../azure/integrations-overview#add-existing-azure-resources-with-connection-strings)
 
 The AppHost resolves the connection string from the `ConnectionStrings__kafka` configuration key. It's possible to set this key by adding the connection string to the AppHost's **appsettings.json** file but this method stores the connection string in plain text and  doesn't protect it. Instead, you can use an environment variable or a user secret to store the connection string:
 

--- a/docs/messaging/kafka-integration.md
+++ b/docs/messaging/kafka-integration.md
@@ -156,7 +156,7 @@ var kafka = builder.ExecutionContext.IsRunMode
 
 The AppHost resolves the connection string from the `ConnectionStrings__kafka` configuration key. It's possible to set this key by adding the connection string to the AppHost's **appsettings.json** file but this method stores the connection string in plain text and  doesn't protect it. Instead, you can use an environment variable or a user secret to store the connection string:
 
-```cmd
+```dotnetcli
 dotnet user-secrets set "ConnectionStrings:kafka" "kafka-broker-1.contoso.com:9092,kafka-broker-2.contoso.com:9092,kafka-broker-3.contoso.com:9092"
 ```
 


### PR DESCRIPTION
## Summary

Describes how to use a connection string to work with existing Kafka clusters. The integration uses the [confluentinc/confluent-local](https://hub.docker.com/r/confluentinc/confluent-local) image, which doesn't support anything complex, such as multiple brokers.

Fixes #3619


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/messaging/kafka-integration.md](https://github.com/dotnet/docs-aspire/blob/1e96af9a9b9beec1022e7ff4c259a3cd5f0180f7/docs/messaging/kafka-integration.md) | [.NET Aspire Apache Kafka integration](https://review.learn.microsoft.com/en-us/dotnet/aspire/messaging/kafka-integration?branch=pr-en-us-4516) |


<!-- PREVIEW-TABLE-END -->