### PR TITLE
Correct Azure CLI to Aspire CLI in documentation

### DIFF
--- a/docs/cli/overview.md
+++ b/docs/cli/overview.md
@@ -23,7 +23,7 @@ The Aspire CLI is an interactive-first experience.
 
 [_Command reference: `aspire new`_](../cli-reference/aspire-new.md)
 
-The `aspire new` command is an interactive-first CLI experience, and is used to create one or more Aspire projects. As part of creating a project, Azure CLI ensures that the latest Aspire project templates are installed into the `dotnet` system.
+The `aspire new` command is an interactive-first CLI experience, and is used to create one or more Aspire projects. As part of creating a project, Aspire CLI ensures that the latest Aspire project templates are installed into the `dotnet` system.
 
 Use the `aspire new` command to create an Aspire project from a list of templates. Once a template is selected, the name of the project is set, and the output folder is chosen, `aspire` downloads the latest templates and generates one or more projects.
 


### PR DESCRIPTION
I've changed Aspire CLI instead of Azure CLI in the documentation to provide better clarity.

## Summary

Describe your changes here.

Fixes #4725 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/cli/overview.md](https://github.com/dotnet/docs-aspire/blob/93b13c9f74a1d237ca57070f91dee70109466697/docs/cli/overview.md) | [Aspire CLI Overview](https://review.learn.microsoft.com/en-us/dotnet/aspire/cli/overview?branch=pr-en-us-4726) |

<!-- PREVIEW-TABLE-END -->