### PR TITLE
Update toc.yml

### DIFF
--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -33,7 +33,7 @@ items:
       href: get-started/dev-containers.md
   - name: What's new in .NET Aspire 9.4
     href: whats-new/dotnet-aspire-9.4.md
-  - name: Upgrade to .NET Aspire 9.4.1
+  - name: Upgrade to .NET Aspire 9.4.2
     href: get-started/upgrade-to-aspire-9.md
 
 - name: Dev-time orchestration


### PR DESCRIPTION
Corrected toc reference to .NET Aspire 9.4.2 
 - Previously incorrectly referenced 9.4.1

## Summary

1 character doc change.



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/toc.yml](https://github.com/dotnet/docs-aspire/blob/b238f3b8a44ebdde9f8420ebf9bc01511464949f/docs/toc.yml) | [docs/toc](https://review.learn.microsoft.com/en-us/dotnet/aspire/toc?branch=pr-en-us-4729) |

<!-- PREVIEW-TABLE-END -->