### PR TITLE
Add preview notice to Dev Tunnels integration

### DIFF
--- a/docs/extensibility/dev-tunnels-integration.md
+++ b/docs/extensibility/dev-tunnels-integration.md
@@ -1,10 +1,10 @@
 ---
-title: .NET Aspire dev tunnels integration
+title: .NET Aspire dev tunnels integration (Preview)
 description: Learn how to use the .NET Aspire dev tunnels integration to securely expose local endpoints publicly during development.
 ms.date: 09/23/2025
 ---
 
-# .NET Aspire dev tunnels integration
+# .NET Aspire dev tunnels integration (Preview)
 
 [!INCLUDE [includes-hosting](../includes/includes-hosting.md)]
 
@@ -33,7 +33,7 @@ To get started with the .NET Aspire dev tunnels integration, install the [📦 A
 ### [.NET CLI](#tab/dotnet-cli)
 
 ```dotnetcli
-dotnet add package Aspire.Hosting.DevTunnels
+dotnet add package Aspire.Hosting.DevTunnels --prerelease
 ```
 
 ### [PackageReference](#tab/package-reference)


### PR DESCRIPTION
## Summary

Looks like the DevTunnels package was released as a preview, added (Preview) to the title and `--prerelease` to the dotnet add package command


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/extensibility/dev-tunnels-integration.md](https://github.com/dotnet/docs-aspire/blob/f2beac1f72c07c12aaa745b8141968b45d2d7e56/docs/extensibility/dev-tunnels-integration.md) | [.NET Aspire dev tunnels integration (Preview)](https://review.learn.microsoft.com/en-us/dotnet/aspire/extensibility/dev-tunnels-integration?branch=pr-en-us-4813) |

<!-- PREVIEW-TABLE-END -->