### PR TITLE
Add command to disable minimum SDK version check

### DIFF
--- a/docs/whats-new/dotnet-aspire-9.5.md
+++ b/docs/whats-new/dotnet-aspire-9.5.md
@@ -100,6 +100,8 @@ Aspire 9.5 introduces infrastructure for .NET 10's new file-based apps feature, 
 ```Aspire
 # Enable file-based AppHost ("apphost.cs") support
 aspire config set features.singlefileAppHostEnabled true
+# Disable the minimum sdk version check
+aspire config set features.minimumSdkCheckEnabled false
 ```
 
 For more information, see [aspire config set command](../cli-reference/aspire-config-set.md).


### PR DESCRIPTION
Added configuration command to disable minimum SDK version check. This is required in 9.5 to use single file apphosts.