### PR TITLE
Fix link for Aspire.Hosting.Kubernetes package

### DIFF
--- a/docs/deployment/overview.md
+++ b/docs/deployment/overview.md
@@ -137,7 +137,7 @@ This example shows how you could explicitly map services to different compute en
 | Integration package | Target | Publish | Deploy | Notes |
 |---------------------|--------|---------|--------|-------|
 | [Aspire.Hosting.Docker](https://www.nuget.org/packages/Aspire.Hosting.Docker) | Docker / Docker Compose | ✅ Yes | ❌ No | Use generated Compose with your own scripts or tooling. |
-| [Aspire.Hosting.Kubernetes](https://www.nuget.org/packages/Aspire.Hosting.Docker) | Kubernetes | ✅ Yes | ❌ No | Apply with `kubectl`, GitOps, or other controllers. |
+| [Aspire.Hosting.Kubernetes](https://www.nuget.org/packages/Aspire.Hosting.Kubernetes) | Kubernetes | ✅ Yes | ❌ No | Apply with `kubectl`, GitOps, or other controllers. |
 | [Aspire.Hosting.Azure.AppContainers](https://www.nuget.org/packages/Aspire.Hosting.Azure.AppContainers) | Azure Container Apps | ✅ Yes | ✅ Yes (Preview) | Deploy capability is in Preview and may change. |
 | [Aspire.Hosting.Azure.AppService](https://www.nuget.org/packages/Aspire.Hosting.Azure.AppService) | Azure App Service | ✅ Yes | ✅ Yes (Preview) | Deploy capability is in Preview and may change. |
 


### PR DESCRIPTION
## Summary

The link to Aspire.Hosting.Kubernetes was wrong: it was pointing to the Aspire.Hosting.Docker package.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/deployment/overview.md](https://github.com/dotnet/docs-aspire/blob/c68305ed2c97fefdac79c3d40a2f86c1b363cbbb/docs/deployment/overview.md) | [Aspire publishing and deployment overview](https://review.learn.microsoft.com/en-us/dotnet/aspire/deployment/overview?branch=pr-en-us-4988) |

<!-- PREVIEW-TABLE-END -->