### PR TITLE
Move data seeding article into Integrations/Tutorials section of TOC

### DIFF
--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -211,6 +211,9 @@ items:
     - name: Messaging using Aspire integrations
       displayName: messaging
       href: messaging/messaging-integrations.md
+    - name: Seed data in a database
+      displayName: seed data,ef core,scripts,entrypoint,init
+      href: database/seed-database-data.md
   - name: Apache Kafka
     displayName: kafka,messaging
     href: messaging/kafka-integration.md
@@ -320,9 +323,6 @@ items:
       href: database/entity-framework-core-integration-overview.md
     - name: Apply migrations
       href: database/ef-core-migrations.md
-    - name: Seed data in a database
-      displayName: seed data,ef core,scripts,entrypoint,init
-      href: database/seed-database-data.md
     - name: Azure Cosmos DB
       displayName: cosmos db,database,ef core
       href: database/azure-cosmos-db-entity-framework-integration.md


### PR DESCRIPTION
## Summary

The [Seed data in a database using Aspire](https://learn.microsoft.com/en-us/dotnet/aspire/database/seed-database-data) article discusses seeding both with SQL Scripts and with EF Core. However, it is currently in the Entity Framework section of the ToC, which may prevent readers finding it if they don't intend to use EF Core.

By moving the article into the Integrations/Tutorials section of the ToC, this PR should make this content easier to find.

Fixes #4980


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/toc.yml](https://github.com/dotnet/docs-aspire/blob/f0c472178251b625c7fd460c20417e467e36df67/docs/toc.yml) | [docs/toc](https://review.learn.microsoft.com/en-us/dotnet/aspire/toc?branch=pr-en-us-5191) |

<!-- PREVIEW-TABLE-END -->