### PR TITLE
Fix formatting in service discovery overview

### DIFF
--- a/docs/service-discovery/overview.md
+++ b/docs/service-discovery/overview.md
@@ -62,7 +62,7 @@ In the preceding JSON:
 
 ### Named endpoints in Aspire
 
-Named endpoints can also be exposed by code in the App Host. For instance the previous example can be modeled as: 
+Named endpoints can also be exposed by code in the App Host. For instance the previous example can be modeled as:
 
 ```csharp
 var basket = builder.AddProject<Projects.BasketService>("basket")


### PR DESCRIPTION
Parameter name is wrong, and added some text to example the sample

```
public static IResourceBuilder<T> WithHttpsEndpoint<T>(this IResourceBuilder<T> builder, int? port = null, int? targetPort = null, [EndpointName] string? name = null, string? env = null, bool isProxied = true) where T : IResourceWithEndpoints
```

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/service-discovery/overview.md](https://github.com/dotnet/docs-aspire/blob/d1e7747ee153fb68692b0df18b626dfc499c4974/docs/service-discovery/overview.md) | [Aspire service discovery](https://review.learn.microsoft.com/en-us/dotnet/aspire/service-discovery/overview?branch=pr-en-us-5306) |


<!-- PREVIEW-TABLE-END -->